### PR TITLE
Only check pull requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,25 +1,10 @@
 const dco = require('./lib/dco');
 
 module.exports = robot => {
-  robot.on('push', async (event, context) => {
-    const github = await robot.auth(event.payload.installation.id);
+  robot.on('pull_request.opened', check);
+  robot.on('pull_request.synchronize', check);
 
-    return event.payload.commits.map(commit => {
-      const signedOff = dco(commit);
-      return github.repos.createStatus(context.repo({
-        sha: commit.id,
-        state: signedOff ? 'success' : 'failure',
-        target_url: 'https://developercertificate.org/',
-        context: 'DCO/commit',
-        description: 'git commit --signoff'
-      }));
-    });
-  });
-
-  robot.on('pull_request.opened', sync);
-  robot.on('pull_request.synchronize', sync);
-
-  async function sync(event, context) {
+  async function check(event, context) {
     const github = await robot.auth(event.payload.installation.id);
     const pr = event.payload.pull_request;
 
@@ -34,7 +19,7 @@ module.exports = robot => {
       sha: pr.head.sha,
       state: signedOff ? 'success' : 'failure',
       target_url: 'https://developercertificate.org/',
-      context: 'DCO/pr',
+      context: 'DCO',
       description: 'git commit --signoff'
     }));
   }


### PR DESCRIPTION
The duplicate statuses (`DOC/commit` and `DCO/pr`) are really annoying. The original idea was to run the check whether commits were pushed to master, or to a branch and added in a pull request. When a commit is pushed to master, you want to run any checks against just that single commit. But when it is part of a pull request, you want to check the status for all the commits, because the status of a PR is determined by the last commit.

Since there's nothing that can be done about commits to master, I think this plugin will have to rely on protected branches and force everything to come in via a PR.