### PR TITLE
truncate long descriptions to first 140 characters and add test

### DIFF
--- a/lib/dco.js
+++ b/lib/dco.js
@@ -23,16 +23,12 @@ module.exports = function (commits) {
     if (!isMerge) {
       if ((match = regex.exec(commit.message)) === null) {
         signedOff = false
-        if (!defaults.failure.description.includes(`The sign-off is missing.`)) {
-          defaults.failure.description += `The sign-off is missing. `
-        }
+        defaults.failure.description = `The sign-off is missing.`
       } else {
         match = regex.exec(commit.message)
         if (commit.author.name !== match[1] || commit.author.email !== match[2]) {
           signedOff = false
-          if (!defaults.failure.description.includes(`Expected`)) {
-            defaults.failure.description += `Expected "${commit.author.name} <${commit.author.email}>", but got "${match[1]} <${match[2]}>" `
-          }
+          defaults.failure.description = `Expected "${commit.author.name} <${commit.author.email}>", but got "${match[1]} <${match[2]}>" `
         }
       }
     }
@@ -40,6 +36,7 @@ module.exports = function (commits) {
   if (signedOff) {
     return defaults.success
   } else {
+    defaults.failure.description = defaults.failure.description.substring(0, 140)
     return defaults.failure
   }
 }

--- a/test/dco.js
+++ b/test/dco.js
@@ -42,7 +42,7 @@ describe('dco', () => {
 
     expect(JSON.stringify(dcoObject)).toBe(JSON.stringify({
       state: 'failure',
-      description: 'The sign-off is missing. ',
+      description: 'The sign-off is missing.',
       target_url: 'https://github.com/probot/dco#how-it-works'
     }))
   })
@@ -164,5 +164,22 @@ describe('dco', () => {
     const dcoObject = getDCOStatus([{commit: commitA, parents: []}, {commit: commitB, parents: []}])
 
     expect(JSON.stringify(dcoObject)).toBe(success)
+  })
+
+  it('returns a 140 character description if the message is more than 140 characters', () => {
+    const commit = {
+      message: 'signed off correctly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+      author: {
+        name: 'bex is the best name ever and is also very long',
+        email: 'bexMyVeryLongAlsoButImportantEmail@disney.com'
+      }
+    }
+    const dcoObject = getDCOStatus([{commit, parents: []}])
+
+    expect(JSON.stringify(dcoObject)).toBe(JSON.stringify({
+      state: 'failure',
+      description: 'Expected "bex is the best name ever and is also very long <bexMyVeryLongAlsoButImportantEmail@disney.com>", but got "hiimbex <hiimbex@disney',
+      target_url: 'https://github.com/probot/dco#how-it-works'
+    }))
   })
 })


### PR DESCRIPTION
Fixes https://github.com/probot/dco/issues/29

Basically before I was trying to provide a solution that could potentially provide explanations for multiple commit errors, now I simply add the the most recent error to the description and pass that error t the description. I also take the first 140 characters of the description to make sure we don't go over the API limit.

I also tested this with a test and woo yay testing