### PR TITLE
WIP: Report errors in a comment

### DIFF
--- a/template.md
+++ b/template.md
@@ -1,0 +1,24 @@
+:x: DCO check failed
+
+This project uses the [Developer Certificate of Origin](https://github.com/probot/dco/#how-it-works) (DCO), which is a lightweight way for you to certify that you wrote or otherwise have the right to submit the code you are contributing to this project.
+
+If you agree with the DCO, add a `Signed-off-by: You Name <your@email.com>` line to each of your commits. You can easily add this with:
+
+```
+$ git rebase --signoff {{ base }}
+```
+
+After adding the DCO signoff to your commits, you will be required to force push your changes to this branch.
+
+```
+$ git push --force
+```
+
+<details>
+  <summary>View status of each commit</summary>
+
+{{#commits}}
+- [{{ short_sha }}]({{ html_url }}) - :{{emoji}}: {{ reason }}
+{{/commits}}
+
+</details>


### PR DESCRIPTION
I was thinking more about the issues we've had with reporting errors to the users (#17, #18, #19, #27, #32), and started exploring a different pattern for it while on a plane the other day.

1. If the DCO check succeeds, everything stays the same
1. If the DCO check fails, the app comments with a friendly error explaining what the DCO is and how to fix the failure, along with a detailed summary of the status for each commit. The URL of this comment is used as the `target_url` for the commit status, so clicking on the failure will jump the user up to this comment.
1. If the DCO check fails again on subsequent pushes, this comment is updated with the latest latest details instead of spamming the user with _another_ comment.

This allows us to avoid building out a heavy web UI (#27) for a while longer, and I think will be a better experience for end-users because it generates a notification on the first failure.

cc @keavy @kdaigle @kytrinyx 