### PR TITLE
Modify How it works for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ The Developer Certificate of Origin (DCO) is a lightweight way for contributors 
 
 > By making a contribution to this project, I certify that:
 >
-> 1. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
+> a. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
 >
-> 2. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
+> b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
 >
-> 3. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+> c. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
 >
-> 4. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+> d. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
 
 Contributors _sign-off_ that they adhere to these requirements by adding a `Signed-off-by` line to commit messages.
 


### PR DESCRIPTION
https://developercertificate.org/ uses `a, b, c, and d` instead of `1, 2, 3, and 4` which helps clarify:
```
> c. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
```