### PR TITLE
Use commit.comitter instead of commit.author in validation

### DIFF
--- a/lib/dco.js
+++ b/lib/dco.js
@@ -27,14 +27,14 @@ module.exports = function (commits) {
         signedOff = false
         defaults.failure.description = `The sign-off is missing.`
       } else {
-        if (!validator.validate(commit.author.email)) {
+        if (!validator.validate(commit.committer.email)) {
           signedOff = false
-          defaults.failure.description = `${commit.author.email} is not a valid email address.`
+          defaults.failure.description = `${commit.committer.email} is not a valid email address.`
         }
         match = regex.exec(commit.message)
-        if (commit.author.name !== match[1] || commit.author.email !== match[2]) {
+        if (commit.comitter.name !== match[1] || commit.committer.email !== match[2]) {
           signedOff = false
-          defaults.failure.description = `Expected "${commit.author.name} <${commit.author.email}>", but got "${match[1]} <${match[2]}>" `
+          defaults.failure.description = `Expected "${commit.committer.name} <${commit.committer.email}>", but got "${match[1]} <${match[2]}>" `
         }
       }
     }

--- a/lib/dco.js
+++ b/lib/dco.js
@@ -27,14 +27,17 @@ module.exports = function (commits) {
         signedOff = false
         defaults.failure.description = `The sign-off is missing.`
       } else {
-        if (!validator.validate(commit.committer.email)) {
+        let email = commit.committer ? commit.committer.email : commit.author.email
+        let name = commit.committer ? commit.committer.name : commit.author.name
+
+        if (!validator.validate(email)) {
           signedOff = false
-          defaults.failure.description = `${commit.committer.email} is not a valid email address.`
+          defaults.failure.description = `${email} is not a valid email address.`
         }
         match = regex.exec(commit.message)
-        if (commit.comitter.name !== match[1] || commit.committer.email !== match[2]) {
+        if (name !== match[1] || email !== match[2]) {
           signedOff = false
-          defaults.failure.description = `Expected "${commit.committer.name} <${commit.committer.email}>", but got "${match[1]} <${match[2]}>" `
+          defaults.failure.description = `Expected "${name} <${email}>", but got "${match[1]} <${match[2]}>" `
         }
       }
     }


### PR DESCRIPTION
Uses `commit.commiter` instead of `commit.author` in name and email validation. Related to https://github.com/probot/dco/issues/39

Signed-off-by: bndw <benjamindwoodward@gmail.com>