### PR TITLE
Do not require sign-off for organization members

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ a GitHub Integration built with [probot](https://github.com/probot/probot) that 
 
 [Configure the integration](https://github.com/integration/dco) for your organization or repositories. Enable [required status checks](docs/required-statuses.md) if you want to enforce the DCO on all commits.
 
+It is possible to disable the check for commits authored and [signed](https://help.github.com/articles/signing-commits-using-gpg/) by members of the organization the repository belongs to. To do this, place the following configuration file in `.github/dco.yml` on the default branch:
+
+```yaml
+require:
+  members: false
+```
+
 See [docs/deploy.md](docs/deploy.md) if you would like to run your own instance of this plugin.
 
 ## How it works

--- a/index.js
+++ b/index.js
@@ -26,20 +26,15 @@ module.exports = robot => {
         return members[login]
       }
 
-      let result
-      try {
-        await context.github.orgs.checkMembership({
-          org: organization,
-          username: login
-        })
-        result = true
-      } catch (err) {
-        if (err.code === 404) {
-          result = false
-        } else {
+      const result = await context.github.orgs.checkMembership({
+        org: organization,
+        username: login
+      }).catch(err => {
+        if (err.code !== 404) {
           throw err
         }
-      }
+        return false
+      })
       members[login] = result
       return result
     }

--- a/index.js
+++ b/index.js
@@ -4,14 +4,49 @@ module.exports = robot => {
   robot.on(['pull_request.opened', 'pull_request.synchronize'], check)
 
   async function check (context) {
+    const config = await context.config('dco.yml', {'require_signoff_for_members': true})
+    const requireSignoffForMembers = config.require_signoff_for_members
+
     const pr = context.payload.pull_request
+    const organization = context.payload.organization.login
 
     const compare = await context.github.repos.compareCommits(context.repo({
       base: pr.base.sha,
       head: pr.head.sha
     }))
 
-    const dcoParams = getDCOStatus(compare.data.commits)
+    const members = {}
+
+    const isOrgMember = async function (login) {
+      if (members.hasOwnProperty(login)) {
+        return members[login]
+      }
+
+      let result
+      try {
+        await context.github.orgs.checkMembership({
+          org: organization,
+          username: login
+        })
+        result = true
+      } catch (err) {
+        if (err.code === 404) {
+          result = false
+        } else {
+          throw err
+        }
+      }
+      members[login] = result
+      return result
+    }
+
+    const dcoParams = await getDCOStatus(compare.data.commits, requireSignoffForMembers
+      ? async () => true
+      : async (author) => {
+        const member = await isOrgMember(author)
+        return !member
+      }
+    )
 
     const params = Object.assign({
       sha: pr.head.sha,

--- a/index.js
+++ b/index.js
@@ -4,8 +4,12 @@ module.exports = robot => {
   robot.on(['pull_request.opened', 'pull_request.synchronize'], check)
 
   async function check (context) {
-    const config = await context.config('dco.yml', {'require_signoff_for_members': true})
-    const requireSignoffForMembers = config.require_signoff_for_members
+    const config = await context.config('dco.yml', {
+      require: {
+        members: true
+      }
+    })
+    const requireForMembers = config.require.members
 
     const pr = context.payload.pull_request
     const organization = context.payload.organization.login
@@ -40,7 +44,7 @@ module.exports = robot => {
       return result
     }
 
-    const dcoParams = await getDCOStatus(compare.data.commits, requireSignoffForMembers
+    const dcoParams = await getDCOStatus(compare.data.commits, requireForMembers
       ? async () => true
       : async (author) => {
         const member = await isOrgMember(author)

--- a/lib/dco.js
+++ b/lib/dco.js
@@ -2,47 +2,45 @@ const validator = require('email-validator')
 
 // Returns the DCO object containing state and description
 // Also returns target_url (in case of failure) in object
-module.exports = function (commits) {
-  const defaults = {
-    success: {
-      state: 'success',
-      description: 'All commits have a DCO sign-off from the author'
-    },
-    failure: {
+module.exports = async function (commits, isRequiredFor) {
+  const regex = /^Signed-off-by: (.*) <(.*)>$/im
+  const failure = (description) => {
+    return {
       state: 'failure',
-      description: '',
+      description: description.substring(0, 140),
       target_url: 'https://github.com/probot/dco#how-it-works'
     }
   }
-  let signedOff = true
 
-  commits.forEach(comm => {
-    const {commit, parents} = comm
+  for (const {commit, author, parents} of commits) {
     const isMerge = parents && parents.length > 1
-    const regex = /^Signed-off-by: (.*) <(.*)>$/im
-    let match
+    if (isMerge) {
+      continue
+    }
 
-    if (!isMerge) {
-      if ((match = regex.exec(commit.message)) === null) {
-        signedOff = false
-        defaults.failure.description = `The sign-off is missing.`
+    const match = regex.exec(commit.message)
+
+    if (match === null) {
+      const signoffRequired = await isRequiredFor(author.login)
+      if (signoffRequired) {
+        return failure(`The sign-off is missing.`)
       } else {
-        if (!validator.validate(commit.author.email)) {
-          signedOff = false
-          defaults.failure.description = `${commit.author.email} is not a valid email address.`
+        if (!commit.verification.verified) {
+          return failure(`Commit by organization member is not verified.`)
         }
-        match = regex.exec(commit.message)
+      }
+    } else {
+      if (!validator.validate(commit.author.email)) {
+        return failure(`${commit.author.email} is not a valid email address.`)
+      } else {
         if (commit.author.name !== match[1] || commit.author.email !== match[2]) {
-          signedOff = false
-          defaults.failure.description = `Expected "${commit.author.name} <${commit.author.email}>", but got "${match[1]} <${match[2]}>" `
+          return failure(`Expected "${commit.author.name} <${commit.author.email}>", but got "${match[1]} <${match[2]}>".`)
         }
       }
     }
-  })
-  if (signedOff) {
-    return defaults.success
-  } else {
-    defaults.failure.description = defaults.failure.description.substring(0, 140)
-    return defaults.failure
+  }
+  return {
+    state: 'success',
+    description: 'All commits have a DCO sign-off from the author'
   }
 }


### PR DESCRIPTION
When `.github/dco.yml` specifies `require_signoff_for_members: false`,
members of the repository's owning organization can skip signing off
their commits, provided the commits are verified.

The rationale is that signoffs are useful when accepting contributions from outside the organization, but represent noise for commits by members of the organization.

Fixes #48.