### PR TITLE
Fix no-sign-off feature for user-owned repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ a GitHub Integration built with [probot](https://github.com/probot/probot) that 
 
 [Configure the integration](https://github.com/integration/dco) for your organization or repositories. Enable [required status checks](docs/required-statuses.md) if you want to enforce the DCO on all commits.
 
+See [docs/deploy.md](docs/deploy.md) if you would like to run your own instance of this plugin.
+
+### Skipping sign-off for organization members
+
 It is possible to disable the check for commits authored and [signed](https://help.github.com/articles/signing-commits-using-gpg/) by members of the organization the repository belongs to. To do this, place the following configuration file in `.github/dco.yml` on the default branch:
 
 ```yaml
@@ -15,7 +19,7 @@ require:
   members: false
 ```
 
-See [docs/deploy.md](docs/deploy.md) if you would like to run your own instance of this plugin.
+When this setting is present on a repository that belongs to a GitHub user (instead of an organization), only the repository owner is allowed to push commits without sign-off.
 
 ## How it works
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,45 @@
 const getDCOStatus = require('./lib/dco.js')
 
+const createRequireFunction = (requireForMembers, context) => {
+  // If members are required to sign-off, then always require sign-off
+  if (requireForMembers) {
+    return async () => true
+  }
+
+  // If repository belongs to an organization, check if user is a member
+  if (context.payload.organization) {
+    const members = {}
+    const organization = context.payload.organization.login
+
+    return async (login) => {
+      let member
+      if (members.hasOwnProperty(login)) {
+        member = members[login]
+      } else {
+        member = await context.github.orgs.checkMembership({
+          org: organization,
+          username: login
+        }).catch(err => {
+          if (err.code !== 404) {
+            throw err
+          }
+          return false
+        })
+        members[login] = member
+      }
+
+      // Sign-off is required for non-members only
+      return !member
+    }
+  }
+
+  // If repository does not belong to an organization, check if user is the owner of the repository
+  const owner = context.payload.repository.owner.login
+  return async (login) => {
+    return login !== owner
+  }
+}
+
 module.exports = robot => {
   robot.on(['pull_request.opened', 'pull_request.synchronize'], check)
 
@@ -12,40 +52,13 @@ module.exports = robot => {
     const requireForMembers = config.require.members
 
     const pr = context.payload.pull_request
-    const organization = context.payload.organization.login
 
     const compare = await context.github.repos.compareCommits(context.repo({
       base: pr.base.sha,
       head: pr.head.sha
     }))
 
-    const members = {}
-
-    const isOrgMember = async function (login) {
-      if (members.hasOwnProperty(login)) {
-        return members[login]
-      }
-
-      const result = await context.github.orgs.checkMembership({
-        org: organization,
-        username: login
-      }).catch(err => {
-        if (err.code !== 404) {
-          throw err
-        }
-        return false
-      })
-      members[login] = result
-      return result
-    }
-
-    const dcoParams = await getDCOStatus(compare.data.commits, requireForMembers
-      ? async () => true
-      : async (author) => {
-        const member = await isOrgMember(author)
-        return !member
-      }
-    )
+    const dcoParams = await getDCOStatus(compare.data.commits, createRequireFunction(requireForMembers, context))
 
     const params = Object.assign({
       sha: pr.head.sha,


### PR DESCRIPTION
When the application is installed on a repository that is owned
by a regular user (as opposed to an organizaton) we now check if
the commit author is the same as the repository owner, and allow
skipping the sign-off only then.

This also fixed a bug that broke DCO on repositories owned by
users. The bug was introduced by #52.