### PR TITLE
add support for robot commits

### DIFF
--- a/lib/dco.js
+++ b/lib/dco.js
@@ -11,20 +11,23 @@ module.exports = async function (commits, isRequiredFor) {
       target_url: 'https://github.com/probot/dco#how-it-works'
     }
   }
+  const success = {
+    state: 'success',
+    description: 'All commits have a DCO sign-off from the author'
+  }
 
   for (const {commit, author, parents} of commits) {
     const isMerge = parents && parents.length > 1
     if (isMerge) {
       continue
     }
-    let isBot = false
     if (commit.author.name.endsWith('[bot]')) {
-      isBot = true
+      return success
     }
 
     const match = regex.exec(commit.message)
 
-    if (match === null && !isBot) {
+    if (match === null) {
       const signoffRequired = await isRequiredFor(author.login)
       if (signoffRequired) {
         return failure(`The sign-off is missing.`)
@@ -34,20 +37,14 @@ module.exports = async function (commits, isRequiredFor) {
         }
       }
     } else {
-      if (!isBot) {
-        if (!validator.validate(commit.author.email)) {
-          return failure(`${commit.author.email} is not a valid email address.`)
-        } else {
-          if (commit.author.name !== match[1] || commit.author.email !== match[2]) {
-            return failure(`Expected "${commit.author.name} <${commit.author.email}>", but got "${match[1]} <${match[2]}>".`)
-          }
+      if (!validator.validate(commit.author.email)) {
+        return failure(`${commit.author.email} is not a valid email address.`)
+      } else {
+        if (commit.author.name !== match[1] || commit.author.email !== match[2]) {
+          return failure(`Expected "${commit.author.name} <${commit.author.email}>", but got "${match[1]} <${match[2]}>".`)
         }
       }
     }
   }
-
-  return {
-    state: 'success',
-    description: 'All commits have a DCO sign-off from the author'
-  }
+  return success
 }

--- a/lib/dco.js
+++ b/lib/dco.js
@@ -17,10 +17,14 @@ module.exports = async function (commits, isRequiredFor) {
     if (isMerge) {
       continue
     }
+    let isBot = false
+    if (commit.author.name.endsWith('[bot]')) {
+      isBot = true
+    }
 
     const match = regex.exec(commit.message)
 
-    if (match === null) {
+    if (match === null && !isBot) {
       const signoffRequired = await isRequiredFor(author.login)
       if (signoffRequired) {
         return failure(`The sign-off is missing.`)
@@ -30,15 +34,18 @@ module.exports = async function (commits, isRequiredFor) {
         }
       }
     } else {
-      if (!validator.validate(commit.author.email)) {
-        return failure(`${commit.author.email} is not a valid email address.`)
-      } else {
-        if (commit.author.name !== match[1] || commit.author.email !== match[2]) {
-          return failure(`Expected "${commit.author.name} <${commit.author.email}>", but got "${match[1]} <${match[2]}>".`)
+      if (!isBot) {
+        if (!validator.validate(commit.author.email)) {
+          return failure(`${commit.author.email} is not a valid email address.`)
+        } else {
+          if (commit.author.name !== match[1] || commit.author.email !== match[2]) {
+            return failure(`Expected "${commit.author.name} <${commit.author.email}>", but got "${match[1]} <${match[2]}>".`)
+          }
         }
       }
     }
   }
+
   return {
     state: 'success',
     description: 'All commits have a DCO sign-off from the author'

--- a/test/dco.test.js
+++ b/test/dco.test.js
@@ -235,6 +235,19 @@ describe('dco', () => {
     }))
   })
 
+  test('returns success when committer is bot', async () => {
+    const commit = {
+      message: 'I aM rObOt I dO wHaT i PlEaSe.',
+      author: {
+        name: 'bexobot [bot]',
+        email: 'wut'
+      }
+    }
+    const dcoObject = await getDCOStatus([{commit, parents: []}], alwaysRequireSignoff)
+
+    expect(JSON.stringify(dcoObject)).toBe(success)
+  })
+
   test(
     'returns success if verified commit without sign off is from org member',
     async () => {


### PR DESCRIPTION
Fixes https://github.com/probot/dco/issues/21 by adding bot support! While I do think it would be better to look at `author.type` to check if it's Bot, that implementation fails all of our existing tests, unless we add an author object to them. I wasn't sure which would be better, but this implementation definitely works.

Thoughts @bkeepers?