### PR TITLE
rewrite logic to be more readable + add author to tests

### DIFF
--- a/lib/dco.js
+++ b/lib/dco.js
@@ -11,40 +11,28 @@ module.exports = async function (commits, isRequiredFor) {
       target_url: 'https://github.com/probot/dco#how-it-works'
     }
   }
-  const success = {
-    state: 'success',
-    description: 'All commits have a DCO sign-off from the author'
-  }
 
   for (const {commit, author, parents} of commits) {
     const isMerge = parents && parents.length > 1
-    if (isMerge) {
+    const signoffRequired = await isRequiredFor(author.login)
+    if (isMerge || author.type === 'Bot' || (!signoffRequired && commit.verification.verified)) {
       continue
     }
-    if (commit.author.name.endsWith('[bot]')) {
-      return success
-    }
-
     const match = regex.exec(commit.message)
 
     if (match === null) {
-      const signoffRequired = await isRequiredFor(author.login)
-      if (signoffRequired) {
-        return failure(`The sign-off is missing.`)
-      } else {
-        if (!commit.verification.verified) {
-          return failure(`Commit by organization member is not verified.`)
-        }
-      }
+      if (signoffRequired) return failure(`The sign-off is missing.`)
+      if (!commit.verification.verified) return failure(`Commit by organization member is not verified.`)
     } else {
-      if (!validator.validate(commit.author.email)) {
-        return failure(`${commit.author.email} is not a valid email address.`)
-      } else {
-        if (commit.author.name !== match[1] || commit.author.email !== match[2]) {
-          return failure(`Expected "${commit.author.name} <${commit.author.email}>", but got "${match[1]} <${match[2]}>".`)
-        }
+      if (!validator.validate(commit.author.email)) return failure(`${commit.author.email} is not a valid email address.`)
+      if (commit.author.name !== match[1] || commit.author.email !== match[2]) {
+        return failure(`Expected "${commit.author.name} <${commit.author.email}>", but got "${match[1]} <${match[2]}>".`)
       }
     }
   }
-  return success
+  return {
+    state: 'success',
+    description: 'All commits have a DCO sign-off from the author',
+    target_url: 'https://github.com/probot/dco#how-it-works'
+  }
 }

--- a/test/dco.test.js
+++ b/test/dco.test.js
@@ -1,6 +1,10 @@
 const getDCOStatus = require('../lib/dco.js')
 
-const success = JSON.stringify({state: 'success', description: 'All commits have a DCO sign-off from the author'})
+const success = JSON.stringify({
+  state: 'success',
+  description: 'All commits have a DCO sign-off from the author',
+  target_url: 'https://github.com/probot/dco#how-it-works'
+})
 const alwaysRequireSignoff = async () => true
 const dontRequireSignoffFor = (allowedLogin) => async (login) => { return login !== allowedLogin }
 
@@ -13,7 +17,7 @@ describe('dco', () => {
         email: 'bkeepers@github.com'
       }
     }
-    const dcoObject = await getDCOStatus([{commit, parents: []}], alwaysRequireSignoff)
+    const dcoObject = await getDCOStatus([{commit, author: { login: 'bkeepers' }, parents: []}], alwaysRequireSignoff)
 
     expect(JSON.stringify(dcoObject)).toBe(success)
   })
@@ -26,7 +30,7 @@ describe('dco', () => {
         email: 'bkeepers@github.com'
       }
     }
-    const dcoObject = await getDCOStatus([{commit, parents: [1, 2]}], alwaysRequireSignoff)
+    const dcoObject = await getDCOStatus([{commit, author: { login: 'bkeepers' }, parents: [1, 2]}], alwaysRequireSignoff)
 
     expect(JSON.stringify(dcoObject)).toBe(success)
   })
@@ -39,7 +43,7 @@ describe('dco', () => {
         email: 'bkeepers@github.com'
       }
     }
-    const dcoObject = await getDCOStatus([{commit, author: {login: 'test'}, parents: []}], alwaysRequireSignoff)
+    const dcoObject = await getDCOStatus([{commit, author: { login: 'bkeepers' }, parents: []}], alwaysRequireSignoff)
 
     expect(JSON.stringify(dcoObject)).toBe(JSON.stringify({
       state: 'failure',
@@ -58,7 +62,7 @@ describe('dco', () => {
           email: 'bex@disney.com'
         }
       }
-      const dcoObject = await getDCOStatus([{commit, parents: []}], alwaysRequireSignoff)
+      const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
 
       expect(JSON.stringify(dcoObject)).toBe(JSON.stringify({
         state: 'failure',
@@ -78,7 +82,7 @@ describe('dco', () => {
           email: 'hiimbex@disney.com'
         }
       }
-      const dcoObject = await getDCOStatus([{commit, parents: []}], alwaysRequireSignoff)
+      const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
 
       expect(JSON.stringify(dcoObject)).toBe(JSON.stringify({
         state: 'failure',
@@ -98,7 +102,7 @@ describe('dco', () => {
           email: 'bex@disney.com'
         }
       }
-      const dcoObject = await getDCOStatus([{commit, parents: []}], alwaysRequireSignoff)
+      const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
 
       expect(JSON.stringify(dcoObject)).toBe(JSON.stringify({
         state: 'failure',
@@ -125,7 +129,7 @@ describe('dco', () => {
           email: 'bex@disney.com'
         }
       }
-      const dcoObject = await getDCOStatus([{commit: commitA, parents: []}, {commit: commitB, parents: []}], alwaysRequireSignoff)
+      const dcoObject = await getDCOStatus([{commit: commitA, author: { login: 'hiimbex' }, parents: []}, {commit: commitB, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
 
       expect(JSON.stringify(dcoObject)).toBe(JSON.stringify({
         state: 'failure',
@@ -152,7 +156,7 @@ describe('dco', () => {
           email: 'bex@disney.com'
         }
       }
-      const dcoObject = await getDCOStatus([{commit: commitA, parents: []}, {commit: commitB, parents: []}], alwaysRequireSignoff)
+      const dcoObject = await getDCOStatus([{commit: commitA, author: { login: 'hiimbex' }, parents: []}, {commit: commitB, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
 
       expect(JSON.stringify(dcoObject)).toBe(JSON.stringify({
         state: 'failure',
@@ -177,7 +181,7 @@ describe('dco', () => {
         email: 'bex@disney.com'
       }
     }
-    const dcoObject = await getDCOStatus([{commit: commitA, parents: []}, {commit: commitB, parents: []}], alwaysRequireSignoff)
+    const dcoObject = await getDCOStatus([{commit: commitA, author: { login: 'hiimbex' }, parents: []}, {commit: commitB, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
 
     expect(JSON.stringify(dcoObject)).toBe(success)
   })
@@ -192,7 +196,7 @@ describe('dco', () => {
           email: 'bexMyVeryLongAlsoButImportantEmail@disney.com'
         }
       }
-      const dcoObject = await getDCOStatus([{commit, parents: []}], alwaysRequireSignoff)
+      const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
 
       expect(JSON.stringify(dcoObject)).toBe(JSON.stringify({
         state: 'failure',
@@ -212,7 +216,7 @@ describe('dco', () => {
           email: 'hiimbex@disney.com'
         }
       }
-      const dcoObject = await getDCOStatus([{commit, parents: []}], alwaysRequireSignoff)
+      const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
 
       expect(JSON.stringify(dcoObject)).toBe(success)
     }
@@ -226,7 +230,7 @@ describe('dco', () => {
         email: 'hiimbex@bexo'
       }
     }
-    const dcoObject = await getDCOStatus([{commit, parents: []}], alwaysRequireSignoff)
+    const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
 
     expect(JSON.stringify(dcoObject)).toBe(JSON.stringify({
       state: 'failure',
@@ -243,7 +247,11 @@ describe('dco', () => {
         email: 'wut'
       }
     }
-    const dcoObject = await getDCOStatus([{commit, parents: []}], alwaysRequireSignoff)
+    const author = {
+      login: 'bexobot [bot]',
+      type: 'Bot'
+    }
+    const dcoObject = await getDCOStatus([{commit, author, parents: []}], alwaysRequireSignoff)
 
     expect(JSON.stringify(dcoObject)).toBe(success)
   })
@@ -261,10 +269,7 @@ describe('dco', () => {
           verified: true
         }
       }
-      const author = {
-        login: 'lptr'
-      }
-      const dcoObject = await getDCOStatus([{commit, author, parents: []}], dontRequireSignoffFor('lptr'))
+      const dcoObject = await getDCOStatus([{commit, author: { login: 'lptr' }, parents: []}], dontRequireSignoffFor('lptr'))
 
       expect(JSON.stringify(dcoObject)).toBe(success)
     }
@@ -283,10 +288,7 @@ describe('dco', () => {
           verified: false
         }
       }
-      const author = {
-        login: 'lptr'
-      }
-      const dcoObject = await getDCOStatus([{commit, author, parents: []}], dontRequireSignoffFor('lptr'))
+      const dcoObject = await getDCOStatus([{commit, author: { login: 'lptr' }, parents: []}], dontRequireSignoffFor('lptr'))
 
       expect(JSON.stringify(dcoObject)).toBe(JSON.stringify({
         state: 'failure',


### PR DESCRIPTION
This PR doesn't actually alter any intended functionality. It

- rewrites the logic of `lib/dco.js` to be more readable and handle more cases in chunks
- changes the if statements to be 1 liners (except for the last one for readability) so now that file might actually be understandable at a quick glance
- adds `author` field to the tests so that we can check earlier in the code for `signoffRequired` and for bot users
- changes the bot user check to `author.type === 'Bot'` which is the most accurate way to check for a bot user (idk if a regular user could make their username have [bot] in it or if that's forbidden, but still)

The next step I wanna take is adding support for checking both the `commit.author.login` and `commit.committer.login` alongside the `commit.author.email` and `commit.committer.email`, but I thought that might be too much for one pr