### PR TITLE
checks for both commit.author and commit.committer

### DIFF
--- a/lib/dco.js
+++ b/lib/dco.js
@@ -24,8 +24,12 @@ module.exports = async function (commits, isRequiredFor) {
       if (signoffRequired) return failure(`The sign-off is missing.`)
       if (!commit.verification.verified) return failure(`Commit by organization member is not verified.`)
     } else {
-      if (!validator.validate(commit.author.email)) return failure(`${commit.author.email} is not a valid email address.`)
-      if (commit.author.name.toLowerCase() !== match[1].toLowerCase() || commit.author.email.toLowerCase() !== match[2].toLowerCase()) {
+      if (!(validator.validate(commit.author.email || commit.committer.email))) {
+        return failure(`${commit.author.email} is not a valid email address.`)
+      }
+      const authors = [commit.author.name.toLowerCase(), commit.committer.name.toLowerCase()]
+      const emails = [commit.author.email.toLowerCase(), commit.committer.email.toLowerCase()]
+      if (!(authors.includes(match[1].toLowerCase())) || !(emails.includes(match[2].toLowerCase()))) {
         return failure(`Expected "${commit.author.name} <${commit.author.email}>", but got "${match[1]} <${match[2]}>".`)
       }
     }

--- a/test/dco.test.js
+++ b/test/dco.test.js
@@ -15,6 +15,10 @@ describe('dco', () => {
       author: {
         name: 'Brandon Keepers',
         email: 'bkeepers@github.com'
+      },
+      committer: {
+        name: 'Bex Warner',
+        email: 'bexmwarner@gmail.com'
       }
     }
     const dcoObject = await getDCOStatus([{commit, author: { login: 'bkeepers' }, parents: []}], alwaysRequireSignoff)
@@ -28,6 +32,10 @@ describe('dco', () => {
       author: {
         name: 'Brandon Keepers',
         email: 'bkeepers@github.com'
+      },
+      committer: {
+        name: 'Bex Warner',
+        email: 'bexmwarner@gmail.com'
       }
     }
     const dcoObject = await getDCOStatus([{commit, author: { login: 'bkeepers' }, parents: [1, 2]}], alwaysRequireSignoff)
@@ -41,6 +49,10 @@ describe('dco', () => {
       author: {
         name: 'Brandon Keepers',
         email: 'bkeepers@github.com'
+      },
+      committer: {
+        name: 'Bex Warner',
+        email: 'bexmwarner@gmail.com'
       }
     }
     const dcoObject = await getDCOStatus([{commit, author: { login: 'bkeepers' }, parents: []}], alwaysRequireSignoff)
@@ -60,6 +72,10 @@ describe('dco', () => {
         author: {
           name: 'hiimbex',
           email: 'bex@disney.com'
+        },
+        committer: {
+          name: 'Bex Warner',
+          email: 'bexmwarner@gmail.com'
         }
       }
       const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
@@ -80,6 +96,10 @@ describe('dco', () => {
         author: {
           name: 'bex',
           email: 'hiimbex@disney.com'
+        },
+        committer: {
+          name: 'Bex Warner',
+          email: 'bexmwarner@gmail.com'
         }
       }
       const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
@@ -100,6 +120,10 @@ describe('dco', () => {
         author: {
           name: 'bex',
           email: 'bex@disney.com'
+        },
+        committer: {
+          name: 'Bex Warner',
+          email: 'bexmwarner@gmail.com'
         }
       }
       const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
@@ -120,6 +144,10 @@ describe('dco', () => {
         author: {
           name: 'bex',
           email: 'bex@disney.com'
+        },
+        committer: {
+          name: 'Bex Warner',
+          email: 'bexmwarner@gmail.com'
         }
       }
       const commitB = {
@@ -127,6 +155,10 @@ describe('dco', () => {
         author: {
           name: 'bex',
           email: 'bex@disney.com'
+        },
+        committer: {
+          name: 'Bex Warner',
+          email: 'bexmwarner@gmail.com'
         }
       }
       const dcoObject = await getDCOStatus([{commit: commitA, author: { login: 'hiimbex' }, parents: []}, {commit: commitB, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
@@ -147,6 +179,10 @@ describe('dco', () => {
         author: {
           name: 'bex',
           email: 'bex@disney.com'
+        },
+        committer: {
+          name: 'Bex Warner',
+          email: 'bexmwarner@gmail.com'
         }
       }
       const commitB = {
@@ -154,6 +190,10 @@ describe('dco', () => {
         author: {
           name: 'bex',
           email: 'bex@disney.com'
+        },
+        committer: {
+          name: 'Bex Warner',
+          email: 'bexmwarner@gmail.com'
         }
       }
       const dcoObject = await getDCOStatus([{commit: commitA, author: { login: 'hiimbex' }, parents: []}, {commit: commitB, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
@@ -172,6 +212,10 @@ describe('dco', () => {
       author: {
         name: 'bex',
         email: 'bex@disney.com'
+      },
+      committer: {
+        name: 'Bex Warner',
+        email: 'bexmwarner@gmail.com'
       }
     }
     const commitB = {
@@ -179,6 +223,10 @@ describe('dco', () => {
       author: {
         name: 'bex',
         email: 'bex@disney.com'
+      },
+      committer: {
+        name: 'Bex Warner',
+        email: 'bexmwarner@gmail.com'
       }
     }
     const dcoObject = await getDCOStatus([{commit: commitA, author: { login: 'hiimbex' }, parents: []}, {commit: commitB, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
@@ -194,6 +242,10 @@ describe('dco', () => {
         author: {
           name: 'bex is the best name ever and is also very long',
           email: 'bexMyVeryLongAlsoButImportantEmail@disney.com'
+        },
+        committer: {
+          name: 'Bex Warner',
+          email: 'bexmwarner@gmail.com'
         }
       }
       const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
@@ -214,6 +266,10 @@ describe('dco', () => {
         author: {
           name: 'hiimbex',
           email: 'hiimbex@disney.com'
+        },
+        committer: {
+          name: 'Bex Warner',
+          email: 'bexmwarner@gmail.com'
         }
       }
       const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
@@ -228,6 +284,10 @@ describe('dco', () => {
       author: {
         name: 'hiimbex',
         email: 'hiimbex@bexo'
+      },
+      committer: {
+        name: 'Bex Warner',
+        email: 'bexmwarner@gmail.com'
       }
     }
     const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
@@ -245,6 +305,10 @@ describe('dco', () => {
       author: {
         name: 'hiimbexo',
         email: 'hiimbex@bexo.com'
+      },
+      committer: {
+        name: 'Bex Warner',
+        email: 'bexmwarner@gmail.com'
       }
     }
     const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
@@ -258,6 +322,10 @@ describe('dco', () => {
       author: {
         name: 'bexobot [bot]',
         email: 'wut'
+      },
+      committer: {
+        name: 'Bex Warner',
+        email: 'bexmwarner@gmail.com'
       }
     }
     const author = {
@@ -278,6 +346,10 @@ describe('dco', () => {
           name: 'Lorant Pinter',
           email: 'lorant.pinter@gmail.com'
         },
+        committer: {
+          name: 'Bex Warner',
+          email: 'bexmwarner@gmail.com'
+        },
         verification: {
           verified: true
         }
@@ -297,6 +369,10 @@ describe('dco', () => {
           name: 'Lorant Pinter',
           email: 'lorant.pinter@gmail.com'
         },
+        committer: {
+          name: 'Bex Warner',
+          email: 'bexmwarner@gmail.com'
+        },
         verification: {
           verified: false
         }
@@ -308,6 +384,26 @@ describe('dco', () => {
         description: 'Commit by organization member is not verified.',
         target_url: 'https://github.com/probot/dco#how-it-works'
       }))
+    }
+  )
+
+  test(
+    'returns success if commit.author is different but commit.committer matches',
+    async () => {
+      const commit = {
+        message: 'What a nice day!\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+        author: {
+          name: 'Bexo',
+          email: 'bexo@gmail.com'
+        },
+        committer: {
+          name: 'Bex Warner',
+          email: 'bexmwarner@gmail.com'
+        }
+      }
+      const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: []}], alwaysRequireSignoff)
+
+      expect(JSON.stringify(dcoObject)).toBe(success)
     }
   )
 })


### PR DESCRIPTION
Finally closes #39 in checking the sign off against `commit.author` and `commit.committer` values

feedback welcome on the implementation, wasn't sure what a better way would be