### PR TITLE
add check for author && author.login to avoid errors when author is null

### DIFF
--- a/lib/dco.js
+++ b/lib/dco.js
@@ -14,7 +14,10 @@ module.exports = async function (commits, isRequiredFor) {
 
   for (const {commit, author, parents} of commits) {
     const isMerge = parents && parents.length > 1
-    const signoffRequired = await isRequiredFor(author.login)
+    let signoffRequired = true
+    if (author && author.login) {
+      signoffRequired = await isRequiredFor(author.login)
+    }
     if (isMerge || author.type === 'Bot' || (!signoffRequired && commit.verification.verified)) {
       continue
     }

--- a/lib/dco.js
+++ b/lib/dco.js
@@ -14,11 +14,10 @@ module.exports = async function (commits, isRequiredFor) {
 
   for (const {commit, author, parents} of commits) {
     const isMerge = parents && parents.length > 1
-    let signoffRequired = true
-    if (author && author.login) {
-      signoffRequired = await isRequiredFor(author.login)
-    }
-    if (isMerge || author.type === 'Bot' || (!signoffRequired && commit.verification.verified)) {
+    const signoffRequired = !author || await isRequiredFor(author.login)
+    if (isMerge || (!signoffRequired && commit.verification.verified)) {
+      continue
+    } else if (!author || author.type === 'Bot') {
       continue
     }
     const match = regex.exec(commit.message)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "eslint-plugin-import": "^2.11.0",
     "jest": "^22.4.3",
-    "nock": "^9.2.5",
+    "nock": "^9.2.6",
     "smee-client": "^1.0.1",
     "standard": "^11.0.0"
   },

--- a/test/dco.test.js
+++ b/test/dco.test.js
@@ -406,4 +406,25 @@ describe('dco', () => {
       expect(JSON.stringify(dcoObject)).toBe(success)
     }
   )
+
+  test(
+    'returns success if author does not exist but everything else is ok',
+    async () => {
+      const commit = {
+        message: 'What a nice day!\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+        author: {
+          name: 'Bexo',
+          email: 'bexo@gmail.com'
+        },
+        committer: {
+          name: 'Bex Warner',
+          email: 'bexmwarner@gmail.com'
+        }
+      }
+      const author = null
+      const dcoObject = await getDCOStatus([{commit, author, parents: []}], alwaysRequireSignoff)
+
+      expect(JSON.stringify(dcoObject)).toBe(success)
+    }
+  )
 })


### PR DESCRIPTION
Closes #69 final issues and [Sentry](https://sentry.io/probot/dco/) Unresolved type error issues.

So this is happening due to commits not being [linked to any user](https://help.github.com/articles/why-are-my-commits-linked-to-the-wrong-user/#commits-are-not-linked-to-any-user), a state which is common for new GitHub accounts/users to be in.

In this state it appears the `author` field is null and we check in DCO for the `author.login` (aka your GitHub login), so I've made the check more thorough to avoid this issue.