### PR TITLE
Fix author being null bug

### DIFF
--- a/lib/dco.js
+++ b/lib/dco.js
@@ -17,7 +17,7 @@ module.exports = async function (commits, isRequiredFor) {
     const signoffRequired = !author || await isRequiredFor(author.login)
     if (isMerge || (!signoffRequired && commit.verification.verified)) {
       continue
-    } else if (!author || author.type === 'Bot') {
+    } else if (author && author.type === 'Bot') {
       continue
     }
     const match = regex.exec(commit.message)

--- a/test/dco.test.js
+++ b/test/dco.test.js
@@ -427,4 +427,29 @@ describe('dco', () => {
       expect(JSON.stringify(dcoObject)).toBe(success)
     }
   )
+
+  test(
+    'returns failure if author does not exist and there is no sign off',
+    async () => {
+      const commit = {
+        message: 'What a nice day!',
+        author: {
+          name: 'Bexo',
+          email: 'bexo@gmail.com'
+        },
+        committer: {
+          name: 'Bex Warner',
+          email: 'bexmwarner@gmail.com'
+        }
+      }
+      const author = null
+      const dcoObject = await getDCOStatus([{commit, author, parents: []}], alwaysRequireSignoff)
+
+      expect(JSON.stringify(dcoObject)).toBe(JSON.stringify({
+        state: 'failure',
+        description: 'The sign-off is missing.',
+        target_url: 'https://github.com/probot/dco#how-it-works'
+      }))
+    }
+  )
 })


### PR DESCRIPTION
Fixes https://github.com/probot/dco/issues/81

In #77 I introduced a regression that caused the DCO to always pass when the author was null which was not intended behavior. 

This PR fixes that issue and adds a test for this scenario.