### PR TITLE
Update standard to v12

### DIFF
--- a/lib/dco.js
+++ b/lib/dco.js
@@ -7,7 +7,7 @@ module.exports = async function (commits, isRequiredFor, prURL) {
   const regex = /^Signed-off-by: (.*) <(.*)>$/im
   let failed = []
 
-  for (const {commit, author, parents, sha} of commits) {
+  for (const { commit, author, parents, sha } of commits) {
     const isMerge = parents && parents.length > 1
     const signoffRequired = !author || await isRequiredFor(author.login)
     if (isMerge || (!signoffRequired && commit.verification.verified)) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "jest": "^22.4.3",
     "nock": "^9.2.6",
     "smee-client": "^1.0.1",
-    "standard": "^11.0.0"
+    "standard": "^12.0.1"
   },
   "standard": {
     "env": [

--- a/test/dco.test.js
+++ b/test/dco.test.js
@@ -19,7 +19,7 @@ describe('dco', () => {
         email: 'bexmwarner@gmail.com'
       }
     }
-    const dcoObject = await getDCOStatus([{commit, author: { login: 'bkeepers' }, parents: [], sha}], alwaysRequireSignoff, prInfo)
+    const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
     expect(dcoObject).toEqual(success)
   })
@@ -36,7 +36,7 @@ describe('dco', () => {
         email: 'bexmwarner@gmail.com'
       }
     }
-    const dcoObject = await getDCOStatus([{commit, author: { login: 'bkeepers' }, parents: [1, 2], sha}], alwaysRequireSignoff, prInfo)
+    const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [1, 2], sha }], alwaysRequireSignoff, prInfo)
 
     expect(dcoObject).toEqual(success)
   })
@@ -53,7 +53,7 @@ describe('dco', () => {
         email: 'bexmwarner@gmail.com'
       }
     }
-    const dcoObject = await getDCOStatus([{commit, author: { login: 'bkeepers' }, parents: [], sha}], alwaysRequireSignoff, prInfo)
+    const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
     expect(dcoObject).toEqual([{
       url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -78,7 +78,7 @@ describe('dco', () => {
           email: 'bexmwarner@gmail.com'
         }
       }
-      const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: [], sha}], alwaysRequireSignoff, prInfo)
+      const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
       expect(dcoObject).toEqual([{
         url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -104,7 +104,7 @@ describe('dco', () => {
           email: 'bexmwarner@gmail.com'
         }
       }
-      const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: [], sha}], alwaysRequireSignoff, prInfo)
+      const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
       expect(dcoObject).toEqual([{
         url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -130,7 +130,7 @@ describe('dco', () => {
           email: 'bexmwarner@gmail.com'
         }
       }
-      const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: [], sha}], alwaysRequireSignoff, prInfo)
+      const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
       expect(dcoObject).toEqual([{
         url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -167,7 +167,7 @@ describe('dco', () => {
           email: 'bexmwarner@gmail.com'
         }
       }
-      const dcoObject = await getDCOStatus([{commit: commitA, author: { login: 'hiimbex' }, parents: [], sha}, {commit: commitB, author: { login: 'hiimbex' }, parents: [], sha}], alwaysRequireSignoff, prInfo)
+      const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
       expect(dcoObject).toEqual([{
         url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -204,7 +204,7 @@ describe('dco', () => {
           email: 'bexmwarner@gmail.com'
         }
       }
-      const dcoObject = await getDCOStatus([{commit: commitA, author: { login: 'hiimbex' }, parents: []}, {commit: commitB, author: { login: 'hiimbex' }, parents: [], sha}], alwaysRequireSignoff, prInfo)
+      const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
       expect(dcoObject).toEqual([{
         url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -239,7 +239,7 @@ describe('dco', () => {
         email: 'bexmwarner@gmail.com'
       }
     }
-    const dcoObject = await getDCOStatus([{commit: commitA, author: { login: 'hiimbex' }, parents: []}, {commit: commitB, author: { login: 'hiimbex' }, parents: [], sha}], alwaysRequireSignoff, prInfo)
+    const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
     expect(dcoObject).toEqual(success)
   })
@@ -258,7 +258,7 @@ describe('dco', () => {
           email: 'bexmwarner@gmail.com'
         }
       }
-      const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: [], sha}], alwaysRequireSignoff, prInfo)
+      const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
       expect(dcoObject).toEqual(success)
     }
@@ -276,7 +276,7 @@ describe('dco', () => {
         email: 'bexmwarner@gmail.com'
       }
     }
-    const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: [], sha}], alwaysRequireSignoff, prInfo)
+    const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
     expect(dcoObject).toEqual([{
       url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -299,7 +299,7 @@ describe('dco', () => {
         email: 'bexmwarner@gmail.com'
       }
     }
-    const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: [], sha}], alwaysRequireSignoff, prInfo)
+    const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
     expect(dcoObject).toEqual(success)
   })
@@ -320,7 +320,7 @@ describe('dco', () => {
       login: 'bexobot [bot]',
       type: 'Bot'
     }
-    const dcoObject = await getDCOStatus([{commit, author, parents: [], sha}], alwaysRequireSignoff, prInfo)
+    const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
     expect(dcoObject).toEqual(success)
   })
@@ -342,7 +342,7 @@ describe('dco', () => {
           verified: true
         }
       }
-      const dcoObject = await getDCOStatus([{commit, author: { login: 'lptr' }, parents: [], sha}], dontRequireSignoffFor('lptr'), prInfo)
+      const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha }], dontRequireSignoffFor('lptr'), prInfo)
 
       expect(dcoObject).toEqual(success)
     }
@@ -365,7 +365,7 @@ describe('dco', () => {
           verified: false
         }
       }
-      const dcoObject = await getDCOStatus([{commit, author: { login: 'lptr' }, parents: [], sha}], dontRequireSignoffFor('lptr'), prInfo)
+      const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha }], dontRequireSignoffFor('lptr'), prInfo)
 
       expect(dcoObject).toEqual([{
         url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -391,7 +391,7 @@ describe('dco', () => {
           email: 'bexmwarner@gmail.com'
         }
       }
-      const dcoObject = await getDCOStatus([{commit, author: { login: 'hiimbex' }, parents: [], sha}], alwaysRequireSignoff, prInfo)
+      const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
       expect(dcoObject).toEqual(success)
     }
@@ -412,7 +412,7 @@ describe('dco', () => {
         }
       }
       const author = null
-      const dcoObject = await getDCOStatus([{commit, author, parents: [], sha}], alwaysRequireSignoff, prInfo)
+      const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
       expect(dcoObject).toEqual(success)
     }
@@ -432,7 +432,7 @@ describe('dco', () => {
         }
       }
       const author = null
-      const dcoObject = await getDCOStatus([{commit, author, parents: [], sha}], alwaysRequireSignoff, prInfo)
+      const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
       expect(dcoObject).toEqual([{
         url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -459,7 +459,7 @@ describe('dco', () => {
         }
       }
       const author = null
-      const dcoObject = await getDCOStatus([{commit, author, parents: [], sha}], alwaysRequireSignoff, prInfo)
+      const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha }], alwaysRequireSignoff, prInfo)
 
       expect(dcoObject).toEqual([{
         url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -24,7 +24,7 @@ describe('dco', () => {
   test('creates a failing check', async () => {
     nock('https://api.github.com')
       .post('/installations/13055/access_tokens')
-      .reply(200, {token: 'test'})
+      .reply(200, { token: 'test' })
 
     nock('https://api.github.com')
       .get('/repos/robotland/test/contents/.github/dco.yml')
@@ -42,13 +42,13 @@ describe('dco', () => {
       })
       .reply(200)
 
-    await probot.receive({event: 'pull_request', payload})
+    await probot.receive({ event: 'pull_request', payload })
   })
 
   test('creates a passing check', async () => {
     nock('https://api.github.com')
       .post('/installations/13055/access_tokens')
-      .reply(200, {token: 'test'})
+      .reply(200, { token: 'test' })
 
     nock('https://api.github.com')
       .get('/repos/octocat/Hello-World/contents/.github/dco.yml')
@@ -66,6 +66,6 @@ describe('dco', () => {
       })
       .reply(200)
 
-    await probot.receive({event: 'pull_request', payload: payloadSuccess})
+    await probot.receive({ event: 'pull_request', payload: payloadSuccess })
   })
 })


### PR DESCRIPTION
Resolves #88

This PR updates to standard v12 (see [changelog](https://standardjs.com/changelog.html#1200---2018-08-28)) and fixes new violations by running `npx standard --fix`.