### PR TITLE
Allow multiple SoB lines

### DIFF
--- a/lib/dco.js
+++ b/lib/dco.js
@@ -4,7 +4,6 @@ const validator = require('email-validator')
 // If commits aren't properly signed signed off
 // Otherwise returns an empty list
 module.exports = async function (commits, isRequiredFor, prURL) {
-  const regex = /^Signed-off-by: (.*) <(.*)>$/im
   let failed = []
 
   for (const { commit, author, parents, sha } of commits) {
@@ -15,7 +14,6 @@ module.exports = async function (commits, isRequiredFor, prURL) {
     } else if (author && author.type === 'Bot') {
       continue
     }
-    const match = regex.exec(commit.message)
 
     const commitInfo = {
       sha,
@@ -25,7 +23,10 @@ module.exports = async function (commits, isRequiredFor, prURL) {
       message: ''
     }
 
-    if (match === null) {
+    const signoffs = getSignoffs(commit)
+
+    if (signoffs.length === 0) {
+      // no signoffs found
       if (signoffRequired) {
         commitInfo['message'] = `The sign-off is missing.`
         failed.push(commitInfo)
@@ -33,18 +34,52 @@ module.exports = async function (commits, isRequiredFor, prURL) {
         commitInfo['message'] = `Commit by organization member is not verified.`
         failed.push(commitInfo)
       }
-    } else {
-      if (!(validator.validate(commit.author.email || commit.committer.email))) {
-        commitInfo['message'] = `${commit.author.email} is not a valid email address.`
-        failed.push(commitInfo)
-      }
-      const authors = [commit.author.name.toLowerCase(), commit.committer.name.toLowerCase()]
-      const emails = [commit.author.email.toLowerCase(), commit.committer.email.toLowerCase()]
-      if (!(authors.includes(match[1].toLowerCase())) || !(emails.includes(match[2].toLowerCase()))) {
-        commitInfo['message'] = `Expected "${commit.author.name} <${commit.author.email}>", but got "${match[1]} <${match[2]}>".`
-        failed.push(commitInfo)
-      }
+
+      continue
     }
-  }
+
+    const email = commit.author.email || commit.committer.email
+    if (!(validator.validate(email))) {
+      commitInfo['message'] = `${email} is not a valid email address.`
+      failed.push(commitInfo)
+      continue
+    }
+
+    const authors = [commit.author.name.toLowerCase(), commit.committer.name.toLowerCase()]
+    const emails = [commit.author.email.toLowerCase(), commit.committer.email.toLowerCase()]
+    if (signoffs.length === 1) {
+      // commit contains one signoff
+      const sig = signoffs[0]
+      if (!(authors.includes(sig.name.toLowerCase())) || !(emails.includes(sig.email.toLowerCase()))) {
+        commitInfo['message'] = `Expected "${commit.author.name} <${commit.author.email}>", but got "${sig.name} <${sig.email}>".`
+        failed.push(commitInfo)
+      }
+    } else {
+      // commit contains multiple signoffs
+      const valid = signoffs.filter(
+        signoff => authors.includes(signoff.name.toLowerCase()) && emails.includes(signoff.email.toLowerCase())
+      )
+
+      if (valid.length === 0) {
+        const got = signoffs.map(sig => `"${sig.name} <${sig.email}>"`).join(', ')
+        commitInfo['message'] = `Can not find "${commit.author.name} <${commit.author.email}>", in [${got}].`
+        failed.push(commitInfo)
+      }
+    } // end if
+  } // end for
   return failed
+}
+
+function getSignoffs (commit) {
+  const regex = /^Signed-off-by: (.*) <(.*)>$/img
+  let matches = []
+  let match
+  while ((match = regex.exec(commit.message)) !== null) {
+    matches.push({
+      name: match[1],
+      email: match[2]
+    })
+  }
+
+  return matches
 }

--- a/test/dco.test.js
+++ b/test/dco.test.js
@@ -24,6 +24,50 @@ describe('dco', () => {
     expect(dcoObject).toEqual(success)
   })
 
+  test('returns true if message contains multiple signoffs', async () => {
+    const commit = {
+      message: 'Hello world\n\n' +
+        'Signed-off-by: Unknown <tester@github.com>\n' +
+        'Signed-off-by: Brandon Keepers <bkeepers@github.com>',
+      author: {
+        name: 'Brandon Keepers',
+        email: 'bkeepers@github.com'
+      },
+      committer: {
+        name: 'Bex Warner',
+        email: 'bexmwarner@gmail.com'
+      }
+    }
+    const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
+
+    expect(dcoObject).toEqual(success)
+  })
+
+  test('returns false if message does not contain valid signoff in multiple signoffs', async () => {
+    const commit = {
+      message: 'Hello world\n\n' +
+        'Signed-off-by: Tester1 <tester1@github.com>\n' +
+        'Signed-off-by: Tester2 <tester2@github.com>',
+      author: {
+        name: 'Author Name',
+        email: 'author@email.com'
+      },
+      committer: {
+        name: 'Committer Name',
+        email: 'committer@email.com'
+      }
+    }
+    const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
+
+    expect(dcoObject).toEqual([{
+      'author': 'Author Name',
+      'committer': 'Committer Name',
+      'message': 'Can not find "Author Name <author@email.com>", in ["Tester1 <tester1@github.com>", "Tester2 <tester2@github.com>"].',
+      'sha': '18aebfa67dde85da0f5099ad70ef647685a05205',
+      'url': 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205'
+    }])
+  })
+
   test('returns true for merge commit', async () => {
     const commit = {
       message: 'mergin stuff',

--- a/test/dco.test.js
+++ b/test/dco.test.js
@@ -24,7 +24,7 @@ describe('dco', () => {
     expect(dcoObject).toEqual(success)
   })
 
-  test('returns true if message contains multiple signoffs', async () => {
+  test('returns true if message contains multiple signoffs including valid', async () => {
     const commit = {
       message: 'Hello world\n\n' +
         'Signed-off-by: Unknown <tester@github.com>\n' +


### PR DESCRIPTION
Fixes https://github.com/probot/dco/issues/75

##### Example

Commit https://github.com/hyperledger/iroha/pull/1832/commits/65631789e50ba4111c4be63bcd21450ad03b3fa3 contains the following message:
```
Add tests for GetRolePermissions query (#1710)

Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>
Signed-off-by: Vadim Reutskiy <reutskiy@soramitsu.co.jp>
```

DCO reaction before this PR:
```
Expected "Vadim Rc sfai.88@gmail.com", but got "Igor Egorov igor@soramitsu.co.jp".
```

DCO reaction after this PR:
```
Can not find "Vadim Rc <sfai.88@gmail.com>", in ["Igor Egorov <igor@soramitsu.co.jp>", "Vadim Reutskiy <reutskiy@soramitsu.co.jp>"].
```

So, DCO is satisfied if it can find at least one valid SoB.
