### PR TITLE
Robot should not be chipper when users have a huge number of commits …

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,5 +120,5 @@ function handleOneCommit (pr, dcoFailed) {
 }
 
 function handleMultipleCommits (pr, commitLength, dcoFailed) {
-  return `You only have ${dcoFailed.length} commits incorrectly signed off! To fix, head to your local branch and run: \n\`\`\`bash\ngit rebase HEAD~${commitLength} --signoff\n\`\`\`\n Now your commits will have your sign off. Next run \n\`\`\`bash\ngit push --force origin ${pr.head.ref}\n\`\`\``
+  return `You have ${dcoFailed.length} commits incorrectly signed off. To fix, head to your local branch and run: \n\`\`\`bash\ngit rebase HEAD~${commitLength} --signoff\n\`\`\`\n Now your commits will have your sign off. Next run \n\`\`\`bash\ngit push --force origin ${pr.head.ref}\n\`\`\``
 }


### PR DESCRIPTION
…that need to be signed-off

Filing this because DCO was chipper about the 180 (out of 180) commits that I needed to sign-off, which isn't really friendly. It's as if the bot was being sarcastic.