### PR TITLE
Fix started at to be per request

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,11 @@ const getDCOStatus = require('./lib/dco.js')
 const requireMembers = require('./lib/requireMembers.js')
 
 module.exports = app => {
-  const timeStart = new Date()
   app.on(['pull_request.opened', 'pull_request.synchronize', 'check_run.rerequested'], check)
 
   async function check (context) {
+    const timeStart = new Date()
+
     const config = await context.config('dco.yml', {
       require: {
         members: true
@@ -99,6 +100,8 @@ module.exports = app => {
   // This option is only presented to users with Write Access to the repo
   app.on('check_run.requested_action', setStatusPass)
   async function setStatusPass (context) {
+    const timeStart = new Date()
+
     return context.github.checks.create(context.repo({
       name: 'DCO',
       head_branch: context.payload.check_run.check_suite.head_branch,


### PR DESCRIPTION
#100 introduced this, and per https://github.com/probot/dco/pull/100#pullrequestreview-189157631 I made it a fairly global thing.

Unfortunately, as shown in https://github.com/probot/dco/pull/100#issuecomment-455832013:
![image](https://user-images.githubusercontent.com/2119212/51434542-f40cd380-1c30-11e9-8663-5f253c187931.png)
> Note: `712m` is imo _slightly_ better than `-1m`, but I can't imagine DCO taking that long to run...

The problem is explained in https://github.com/probot/dco/pull/100#issuecomment-455832161