### PR TITLE
fix: use "--force-with-lease" instead of "--force" in push hint

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,9 +119,9 @@ module.exports = app => {
 }
 
 function handleOneCommit (pr, dcoFailed) {
-  return `You only have one commit incorrectly signed off! To fix, head to your local branch and run: \n\`\`\`bash\ngit commit --amend --signoff\n\`\`\`\nNow your commits will have your sign off. Next run \n\`\`\`bash\ngit push --force origin ${pr.head.ref}\n\`\`\``
+  return `You only have one commit incorrectly signed off! To fix, head to your local branch and run: \n\`\`\`bash\ngit commit --amend --signoff\n\`\`\`\nNow your commits will have your sign off. Next run \n\`\`\`bash\ngit push --force-with-lease origin ${pr.head.ref}\n\`\`\``
 }
 
 function handleMultipleCommits (pr, commitLength, dcoFailed) {
-  return `You have ${dcoFailed.length} commits incorrectly signed off. To fix, head to your local branch and run: \n\`\`\`bash\ngit rebase HEAD~${commitLength} --signoff\n\`\`\`\n Now your commits will have your sign off. Next run \n\`\`\`bash\ngit push --force origin ${pr.head.ref}\n\`\`\``
+  return `You have ${dcoFailed.length} commits incorrectly signed off. To fix, head to your local branch and run: \n\`\`\`bash\ngit rebase HEAD~${commitLength} --signoff\n\`\`\`\n Now your commits will have your sign off. Next run \n\`\`\`bash\ngit push --force-with-lease origin ${pr.head.ref}\n\`\`\``
 }

--- a/test/fixtures/check_run.created-success.json
+++ b/test/fixtures/check_run.created-success.json
@@ -7,7 +7,7 @@
   "completed_at": "2018-07-14T18:18:54.156Z",
   "output": {
     "title": "DCO",
-    "summary": "You only have one commit incorrectly signed off! To fix, head to your local branch and run: \n```bash\ngit commit --amend --signoff\n```\nNow your commits will have your sign off. Next run \n```bash\ngit push --force origin changes\n```\n\nCommit sha: [6dcb09b](https://github.com/octocat/Hello-World/pull/1/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e), Author: Monalisa Octocat, Committer: Monalisa Octocat; The sign-off is missing."
+    "summary": "You only have one commit incorrectly signed off! To fix, head to your local branch and run: \n```bash\ngit commit --amend --signoff\n```\nNow your commits will have your sign off. Next run \n```bash\ngit push --force-with-lease origin changes\n```\n\nCommit sha: [6dcb09b](https://github.com/octocat/Hello-World/pull/1/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e), Author: Monalisa Octocat, Committer: Monalisa Octocat; The sign-off is missing."
   },
   "actions": [ {
     "label": "Set DCO to pass",

--- a/test/fixtures/check_run.created.json
+++ b/test/fixtures/check_run.created.json
@@ -7,7 +7,7 @@
   "completed_at": "2018-07-14T18:18:54.156Z",
   "output": {
     "title": "DCO",
-    "summary": "You only have one commit incorrectly signed off! To fix, head to your local branch and run: \n```bash\ngit commit --amend --signoff\n```\nNow your commits will have your sign off. Next run \n```bash\ngit push --force origin dco-test\n```\n\nCommit sha: [e76ed60](https://github.com/robotland/test/pull/113/commits/e76ed6025cec8879c75454a6efd6081d46de4c94), Author: Brandon Keepers, Committer: GitHub; The sign-off is missing."
+    "summary": "You only have one commit incorrectly signed off! To fix, head to your local branch and run: \n```bash\ngit commit --amend --signoff\n```\nNow your commits will have your sign off. Next run \n```bash\ngit push --force-with-lease origin dco-test\n```\n\nCommit sha: [e76ed60](https://github.com/robotland/test/pull/113/commits/e76ed6025cec8879c75454a6efd6081d46de4c94), Author: Brandon Keepers, Committer: GitHub; The sign-off is missing."
   },
   "actions": [ {
     "label": "Set DCO to pass",


### PR DESCRIPTION
The instructions given to users when they're signing off commits currently tell users to use `git push --force`, which is unsafe compared to `git push --force-with-lease`.

Here's a blog post that says it in much more detail than I ever could: https://developer.atlassian.com/blog/2015/04/force-with-lease/
