### PR TITLE
feat: use `--no-edit` flag to improve signing for a single commit

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ module.exports = ({ app }) => {
 }
 
 function handleOneCommit (pr, dcoFailed) {
-  return `You only have one commit incorrectly signed off! To fix, first ensure you have a local copy of your branch by [checking out the pull request locally via command line](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally). Next, head to your local branch and run: \n\`\`\`bash\ngit commit --amend --signoff\n\`\`\`\nNow your commits will have your sign off. Next run \n\`\`\`bash\ngit push --force-with-lease origin ${pr.head.ref}\n\`\`\``
+  return `You only have one commit incorrectly signed off! To fix, first ensure you have a local copy of your branch by [checking out the pull request locally via command line](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally). Next, head to your local branch and run: \n\`\`\`bash\ngit commit --amend --no-edit --signoff\n\`\`\`\nNow your commits will have your sign off. Next run \n\`\`\`bash\ngit push --force-with-lease origin ${pr.head.ref}\n\`\`\``
 }
 
 function handleMultipleCommits (pr, commitLength, dcoFailed) {

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -26,7 +26,7 @@ Object {
   "output": Object {
     "summary": "You only have one commit incorrectly signed off! To fix, first ensure you have a local copy of your branch by [checking out the pull request locally via command line](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally). Next, head to your local branch and run: 
 \`\`\`bash
-git commit --amend --signoff
+git commit --amend --no-edit --signoff
 \`\`\`
 Now your commits will have your sign off. Next run 
 \`\`\`bash
@@ -58,7 +58,7 @@ Object {
   "output": Object {
     "summary": "You only have one commit incorrectly signed off! To fix, first ensure you have a local copy of your branch by [checking out the pull request locally via command line](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally). Next, head to your local branch and run: 
 \`\`\`bash
-git commit --amend --signoff
+git commit --amend --no-edit --signoff
 \`\`\`
 Now your commits will have your sign off. Next run 
 \`\`\`bash


### PR DESCRIPTION
Fixes #144.
