### PR TITLE
Add support for remediation commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,35 @@ a GitHub Integration built with [probot](https://github.com/probot/probot) that 
 
 See [docs/deploy.md](docs/deploy.md) if you would like to run your own instance of this plugin.
 
+## Modes of operations
+
+### Default
+
+By default, Probot DCO enforces the presence of [valid DCO signoffs](#how-it-works) on all commits (excluding bots and merges). If a PRs contains commits that lack a valid Signed-off-by line, they are blocked until a correctly signed-off revision of the commit is pushed. This closely mirrors the upstream Linux kernel process.
+
+### Individual remediation commit support
+
+Optionally, a project can allow individual remediation commit support, where the failing commit's author can push an additional properly signed-off commit with additional text in the commit log that indicates they apply their signoff retroactively.
+
+To enable this, place the following configuration file in `.github/dco.yml` on the default branch:
+
+```yaml
+allowRemediationCommits:
+  individual: true
+```
+
+### Third-party remediation support
+
+Additionally, a project can allow third-parties to sign off on an author's behalf by pushing an additional properly signed-off commit with additional text in the commit log that indicates they sign off on behalf of the author. Third-party remediation requires individual remediation to be enabled.
+
+To enable this, place the following configuration file in `.github/dco.yml` on the default branch:
+
+```yaml
+allowRemediationCommits:
+  individual: true
+  thirdParty: true
+```
+
 ### Skipping sign-off for organization members
 
 It is possible to disable the check for commits authored and [signed](https://help.github.com/articles/signing-commits-using-gpg/) by members of the organization the repository belongs to. To do this, place the following configuration file in `.github/dco.yml` on the default branch:

--- a/index.js
+++ b/index.js
@@ -169,11 +169,10 @@ module.exports = ({ app }) => {
 }
 
 function handleCommits (pr, commitLength, dcoFailed, allowRemediationCommits) {
-
   let returnMessage = ''
 
-  if (dcoFailed.length == 1) {
-    returnMessage = `There is one commit incorrectly signed off.  This means that the author of this commit failed to include a Signed-off-by line in the commit message.\n\n`
+  if (dcoFailed.length === 1) {
+    returnMessage = 'There is one commit incorrectly signed off.  This means that the author of this commit failed to include a Signed-off-by line in the commit message.\n\n'
   } else {
     returnMessage = `There are ${dcoFailed.length} commits incorrectly signed off.  This means that the author(s) of these commits failed to include a Signed-off-by line in their commit message.\n\n`
   }
@@ -192,9 +191,9 @@ A *DCO Remediation Commit* contains special text in the commit message that appl
 These authors can unblock this PR by adding a new commit to this branch with the following text in their commit message:\n`
 
     let currentAuthor = ''
-    dcoFailed.forEach(function (commit,index,dcoFailed) {
+    dcoFailed.forEach(function (commit, index, dcoFailed) {
       // If the author has changed, we need to write a new section and close any old sections
-      if (currentAuthor != commit.author + ' <' + commit.email + '>') {
+      if (currentAuthor !== commit.author + ' <' + commit.email + '>') {
         // If currentAuthor was already defined it's the end of a section, so write the Signed-off-by
         if (currentAuthor) {
           returnMessage = returnMessage + `\nSigned-off-by: ${currentAuthor}\n\`\`\`\n`
@@ -204,7 +203,7 @@ These authors can unblock this PR by adding a new commit to this branch with the
         returnMessage = returnMessage + `#### ${commit.author} &lt;${commit.email}&gt;\n\`\`\`\nDCO Remediation Commit for ${commit.author} <${commit.email}>\n\n`
       }
       // Draft the magic DCO remediation commit text for the author
-      //returnMessage = returnMessage + `I, ${commit.author} <${commit.email}> ${commit.sha}\n`
+      // returnMessage = returnMessage + `I, ${commit.author} <${commit.email}> ${commit.sha}\n`
       returnMessage = returnMessage + `I, ${currentAuthor}, hereby add my Signed-off-by to this commit: ${commit.sha}\n`
 
       if (index === dcoFailed.length - 1) {
@@ -212,10 +211,9 @@ These authors can unblock this PR by adding a new commit to this branch with the
       }
     })
 
-    returnMessage = returnMessage + `\n\nPlease note: You should avoid adding empty commits (i.e., \`git commit -s --allow-empty\`), because these will be discarded if someone rebases the branch / repo.\n`
+    returnMessage = returnMessage + '\n\nPlease note: You should avoid adding empty commits (i.e., `git commit -s --allow-empty`), because these will be discarded if someone rebases the branch / repo.\n'
 
     if (allowRemediationCommits.thirdParty) {
-
       returnMessage = returnMessage + `\n---\n\n### Alternate method: An employer adds a DCO Remediation Commit
 
 If the contents of this commit were contributed on behalf of a third party (generally, the author’s employer), an authorized individual may add a Third-Party DCO Remediation Commit.  This may be necessary if the original author is unavailable to add their own DCO Remediation Commit to this branch.
@@ -227,30 +225,30 @@ This PR can be unblocked by an authorized third party adding one or more new com
 For the sake of clarity, please use a separate commit per author:\n`
 
       currentAuthor = ''
-      dcoFailed.forEach(function (commit,index,dcoFailed) {
+      dcoFailed.forEach(function (commit, index, dcoFailed) {
         // If the author has changed, we need to write a new section and close any old sections
-        if (currentAuthor != commit.author + ' <' + commit.email + '>') {
+        if (currentAuthor !== commit.author + ' <' + commit.email + '>') {
           // If currentAuthor was already defined it's the end of a section, so write the Signed-off-by
           if (currentAuthor) {
-            returnMessage = returnMessage + `\nSigned-off-by: YOUR_NAME <YOUR_EMAIL>\n\`\`\`\n`
+            returnMessage = returnMessage + '\nSigned-off-by: YOUR_NAME <YOUR_EMAIL>\n```\n'
           }
           // Update the currentAuthor and write a new section
           currentAuthor = commit.author + ' <' + commit.email + '>'
           returnMessage = returnMessage + `#### On behalf of ${commit.author} &lt;${commit.email}&gt;\n\`\`\`\nThird-Party DCO Remediation Commit for ${commit.author} <${commit.email}>\n\n`
         }
         // Draft the magic DCO remediation commit text for the author
-        //returnMessage = returnMessage + `Retroactive-signed-off-by: ${commit.author} <${commit.email}> ${commit.sha}\n`
+        // returnMessage = returnMessage + `Retroactive-signed-off-by: ${commit.author} <${commit.email}> ${commit.sha}\n`
         returnMessage = returnMessage + `On behalf of ${commit.author} <${commit.email}>, I, YOUR_NAME <YOUR_EMAIL>, hereby add my Signed-off-by to this commit: ${commit.sha}\n`
         console.log(commit.sha)
         if (index === dcoFailed.length - 1) {
-          returnMessage = returnMessage + `\nSigned-off-by: YOUR_NAME <YOUR_EMAIL>\n\`\`\`\n`
+          returnMessage = returnMessage + '\nSigned-off-by: YOUR_NAME <YOUR_EMAIL>\n```\n'
         }
       })
     }
     rebaseWarning = 'Least preferred method: '
   }
 
-  returnMessage = returnMessage + `\n---\n\n### ` + rebaseWarning + `Rebase the branch
+  returnMessage = returnMessage + '\n---\n\n### ' + rebaseWarning + `Rebase the branch
 
 If you have a local git environment and meet the criteria below, one option is to rebase the branch and add your Signed-off-by lines in the new commits.  Please note that if others have already begun work based upon the commits in this branch, this solution will rewrite history and may cause serious issues for collaborators ([described in the git documentation](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) under "The Perils of Rebasing").
 

--- a/index.js
+++ b/index.js
@@ -182,7 +182,75 @@ function handleCommits (pr, commitLength, dcoFailed, allowRemediationCommits) {
 
 Here is how to fix the problem so that this code can be merged.\n\n`
 
-  returnMessage = returnMessage + `\n---\n\n### Rebase the branch
+  let rebaseWarning = ''
+
+  if (allowRemediationCommits.individual || allowRemediationCommits.thirdparty) {
+    returnMessage = returnMessage + `---\n\n### Preferred method: Commit author adds a DCO remediation commit
+
+A *DCO Remediation Commit* contains special text in the commit message that applies a missing Signed-off-by line in a subsequent commit.  The primary benefit of this method is that the project’s history does not change, and there is no risk of breaking someone else’s work.
+
+These authors can unblock this PR by adding a new commit to this branch with the following text in their commit message:\n`
+
+    let currentAuthor = ''
+    dcoFailed.forEach(function (commit,index,dcoFailed) {
+      // If the author has changed, we need to write a new section and close any old sections
+      if (currentAuthor != commit.author + ' <' + commit.email + '>') {
+        // If currentAuthor was already defined it's the end of a section, so write the Signed-off-by
+        if (currentAuthor) {
+          returnMessage = returnMessage + `\nSigned-off-by: ${currentAuthor}\n\`\`\`\n`
+        }
+        // Update the currentAuthor and write a new section
+        currentAuthor = commit.author + ' <' + commit.email + '>'
+        returnMessage = returnMessage + `#### ${commit.author} &lt;${commit.email}&gt;\n\`\`\`\nDCO Remediation Commit for ${commit.author} <${commit.email}>\n\n`
+      }
+      // Draft the magic DCO remediation commit text for the author
+      //returnMessage = returnMessage + `I, ${commit.author} <${commit.email}> ${commit.sha}\n`
+      returnMessage = returnMessage + `I, ${currentAuthor}, hereby add my Signed-off-by to this commit: ${commit.sha}\n`
+
+      if (index === dcoFailed.length - 1) {
+        returnMessage = returnMessage + `\nSigned-off-by: ${currentAuthor}\n\`\`\`\n`
+      }
+    })
+
+    returnMessage = returnMessage + `\n\nPlease note: You should avoid adding empty commits (i.e., \`git commit -s --allow-empty\`), because these will be discarded if someone rebases the branch / repo.\n`
+
+    if (allowRemediationCommits.thirdParty) {
+
+      returnMessage = returnMessage + `\n---\n\n### Alternate method: An employer adds a DCO Remediation Commit
+
+If the contents of this commit were contributed on behalf of a third party (generally, the author’s employer), an authorized individual may add a Third-Party DCO Remediation Commit.  This may be necessary if the original author is unavailable to add their own DCO Remediation Commit to this branch.
+
+If you are about to add a Third-Party DCO Remediation Commit under DCO section (b) or (c), be sure you are authorized by your employer to take this action.  Generally speaking, maintainers and other project contributors cannot sign off on behalf of project contributors, unless there is some relationship which permits this action.  It is your responsibility to verify this.
+
+This PR can be unblocked by an authorized third party adding one or more new commits to this branch with the following text in the commit message.  Replace YOUR_COMPANY with your company name, YOUR_NAME with the name of the authorized representative, and YOUR_EMAIL with the representative’s email address.
+
+For the sake of clarity, please use a separate commit per author:\n`
+
+      currentAuthor = ''
+      dcoFailed.forEach(function (commit,index,dcoFailed) {
+        // If the author has changed, we need to write a new section and close any old sections
+        if (currentAuthor != commit.author + ' <' + commit.email + '>') {
+          // If currentAuthor was already defined it's the end of a section, so write the Signed-off-by
+          if (currentAuthor) {
+            returnMessage = returnMessage + `\nSigned-off-by: YOUR_NAME <YOUR_EMAIL>\n\`\`\`\n`
+          }
+          // Update the currentAuthor and write a new section
+          currentAuthor = commit.author + ' <' + commit.email + '>'
+          returnMessage = returnMessage + `#### On behalf of ${commit.author} &lt;${commit.email}&gt;\n\`\`\`\nThird-Party DCO Remediation Commit for ${commit.author} <${commit.email}>\n\n`
+        }
+        // Draft the magic DCO remediation commit text for the author
+        //returnMessage = returnMessage + `Retroactive-signed-off-by: ${commit.author} <${commit.email}> ${commit.sha}\n`
+        returnMessage = returnMessage + `On behalf of ${commit.author} <${commit.email}>, I, YOUR_NAME <YOUR_EMAIL>, hereby add my Signed-off-by to this commit: ${commit.sha}\n`
+        console.log(commit.sha)
+        if (index === dcoFailed.length - 1) {
+          returnMessage = returnMessage + `\nSigned-off-by: YOUR_NAME <YOUR_EMAIL>\n\`\`\`\n`
+        }
+      })
+    }
+    rebaseWarning = 'Least preferred method: '
+  }
+
+  returnMessage = returnMessage + `\n---\n\n### ` + rebaseWarning + `Rebase the branch
 
 If you have a local git environment and meet the criteria below, one option is to rebase the branch and add your Signed-off-by lines in the new commits.  Please note that if others have already begun work based upon the commits in this branch, this solution will rewrite history and may cause serious issues for collaborators ([described in the git documentation](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) under "The Perils of Rebasing").
 

--- a/lib/dco.js
+++ b/lib/dco.js
@@ -23,16 +23,16 @@ module.exports = async function (commits, isRequiredFor, prURL, allowRemediation
       committer: commit.committer.name,
       message: ''
     }
-	
-    const signoffs = getSignoffs(commit,sha,commits,allowRemediationCommits)
+
+    const signoffs = getSignoffs(commit, sha, commits, allowRemediationCommits)
 
     if (signoffs.length === 0) {
       // no signoffs found
       if (signoffRequired) {
-        commitInfo.message = `The sign-off is missing.`
+        commitInfo.message = 'The sign-off is missing.'
         failed.push(commitInfo)
       } else if (!commit.verification.verified) {
-        commitInfo.message = `Commit by organization member is not verified.`
+        commitInfo.message = 'Commit by organization member is not verified.'
         failed.push(commitInfo)
       }
 
@@ -54,11 +54,11 @@ module.exports = async function (commits, isRequiredFor, prURL, allowRemediation
       const sig = signoffs[0]
       // if the signoff is an explicit match or an individual remediation, check if signoff name and email match the commit
       // if the signoff is from a third-party remediation and passed the tests in getSignoffs, it is valid
-      if ((['explicit','individualRemediation'].includes(sig.type)) &&   
+      if ((['explicit', 'individualRemediation'].includes(sig.type)) &&
         (!(authors.includes(sig.name.toLowerCase())) ||
         !(emails.includes(sig.email.toLowerCase())))) {
-	      commitInfo.message = `Expected "${commit.author.name} <${commit.author.email}>", but got "${sig.name} <${sig.email}>".`
-    	  failed.push(commitInfo)
+        commitInfo.message = `Expected "${commit.author.name} <${commit.author.email}>", but got "${sig.name} <${sig.email}>".`
+        failed.push(commitInfo)
       }
     } else {
       // commit contains multiple signoffs
@@ -68,7 +68,7 @@ module.exports = async function (commits, isRequiredFor, prURL, allowRemediation
       )
       // next, find individual remediations which match the author exactly
       const validIndividualRemediation = signoffs.filter(
-      	signoff => authors.includes(signoff.name.toLowerCase()) && emails.includes(signoff.email.toLowerCase()) && (signoff.type === 'individualRemediation')
+        signoff => authors.includes(signoff.name.toLowerCase()) && emails.includes(signoff.email.toLowerCase()) && (signoff.type === 'individualRemediation')
       )
       // if the signoff is from a third-party remediation and passed the tests in getSignoffs, it is valid
       const validThirdPartyRemediation = signoffs.filter(
@@ -83,13 +83,13 @@ module.exports = async function (commits, isRequiredFor, prURL, allowRemediation
     } // end if
   } // end for
   if (failed) {
-    return failed.sort((a,b) => a.author.localeCompare(b.author))
+    return failed.sort((a, b) => a.author.localeCompare(b.author))
   } else {
     return []
   }
 }
 
-function getSignoffs (comparisonCommit,comparisonSha,allCommits,allowRemediationCommits) {
+function getSignoffs (comparisonCommit, comparisonSha, allCommits, allowRemediationCommits) {
   const regex = /^Signed-off-by: (.*) <(.*)>\s*$/img
   const matches = []
   let match
@@ -104,16 +104,14 @@ function getSignoffs (comparisonCommit,comparisonSha,allCommits,allowRemediation
   if (allowRemediationCommits.individual) {
     // if individual remediation commits are allowed, look for one in the PR with a matching sha
 
-    for (const { commit, author, parents, sha } of allCommits) {
-
+    for (const { commit } of allCommits) {
       let remediationMatch
 
       // if individual commits are allowed, look for one in the PR with a matching sha
       const remediationRegexIndividual = /^I, (.*) <(.*)>, hereby add my Signed-off-by to this commit: (.*)\s*$/img
       while ((remediationMatch = remediationRegexIndividual.exec(commit.message)) !== null) {
-
         // make sure the commit author matches the author being Signed-off-by for
-        if ((remediationMatch[3] === comparisonSha) && 
+        if ((remediationMatch[3] === comparisonSha) &&
            (comparisonCommit.author.name.toLowerCase() === commit.author.name.toLowerCase()) &&
            (comparisonCommit.author.name.toLowerCase() === remediationMatch[1].toLowerCase()) &&
            (comparisonCommit.author.email.toLowerCase() === commit.author.email.toLowerCase()) &&
@@ -127,9 +125,8 @@ function getSignoffs (comparisonCommit,comparisonSha,allCommits,allowRemediation
       } // end while
 
       if (allowRemediationCommits.thirdParty) {
-
         // if 3rd party commits are allowed, look for one in the PR with a matching sha
-        let remediationRegexThirdParty =  /^On behalf of (.*) <(.*)>, I, (.*) <(.*)>, hereby add my Signed-off-by to this commit: (.*)\s*$/img
+        const remediationRegexThirdParty = /^On behalf of (.*) <(.*)>, I, (.*) <(.*)>, hereby add my Signed-off-by to this commit: (.*)\s*$/img
         while ((remediationMatch = remediationRegexThirdParty.exec(commit.message)) !== null) {
           // make sure the commit author or committer matches the person claiming to do the third-party remediation, and that the signoff matches the original failing commit
 
@@ -137,10 +134,9 @@ function getSignoffs (comparisonCommit,comparisonSha,allCommits,allowRemediation
              (comparisonCommit.author.name.toLowerCase() === remediationMatch[1].toLowerCase()) &&
              (comparisonCommit.author.email.toLowerCase() === remediationMatch[2].toLowerCase()) &&
              (((commit.author.name.toLowerCase() === remediationMatch[3].toLowerCase()) &&
-             (commit.author.email.toLowerCase() === remediationMatch[4].toLowerCase())) || 
+             (commit.author.email.toLowerCase() === remediationMatch[4].toLowerCase())) ||
              ((commit.committer.name.toLowerCase() === remediationMatch[3].toLowerCase()) &&
              (commit.committer.email.toLowerCase() === remediationMatch[4].toLowerCase())))) {
-
             matches.push({
               name: remediationMatch[1],
               email: remediationMatch[2],
@@ -150,7 +146,7 @@ function getSignoffs (comparisonCommit,comparisonSha,allCommits,allowRemediation
         } // end while
       } // end if
     } // end if
-  } //end if
+  } // end if
 
   return matches
 }

--- a/lib/dco.js
+++ b/lib/dco.js
@@ -19,6 +19,7 @@ module.exports = async function (commits, isRequiredFor, prURL) {
       sha,
       url: `${prURL}/commits/${sha}`,
       author: commit.author.name,
+      email: commit.author.email,
       committer: commit.committer.name,
       message: ''
     }
@@ -71,7 +72,7 @@ module.exports = async function (commits, isRequiredFor, prURL) {
 }
 
 function getSignoffs (commit) {
-  const regex = /^Signed-off-by: (.*) <(.*)>$/img
+  const regex = /^Signed-off-by: (.*) <(.*)>\s*$/img
   const matches = []
   let match
   while ((match = regex.exec(commit.message)) !== null) {

--- a/lib/dco.js
+++ b/lib/dco.js
@@ -3,7 +3,7 @@ const validator = require('email-validator')
 // Returns a list containing failed commit error messages
 // If commits aren't properly signed signed off
 // Otherwise returns an empty list
-module.exports = async function (commits, isRequiredFor, prURL) {
+module.exports = async function (commits, isRequiredFor, prURL, allowRemediationCommits) {
   const failed = []
 
   for (const { commit, author, parents, sha } of commits) {

--- a/lib/dco.js
+++ b/lib/dco.js
@@ -23,22 +23,23 @@ module.exports = async function (commits, isRequiredFor, prURL, allowRemediation
       committer: commit.committer.name,
       message: ''
     }
-
-    const signoffs = getSignoffs(commit)
+	
+    const signoffs = getSignoffs(commit,sha,commits,allowRemediationCommits)
 
     if (signoffs.length === 0) {
       // no signoffs found
       if (signoffRequired) {
-        commitInfo.message = 'The sign-off is missing.'
+        commitInfo.message = `The sign-off is missing.`
         failed.push(commitInfo)
       } else if (!commit.verification.verified) {
-        commitInfo.message = 'Commit by organization member is not verified.'
+        commitInfo.message = `Commit by organization member is not verified.`
         failed.push(commitInfo)
       }
 
       continue
     }
 
+    // Check to be sure the author and committer emails are actual valid email addresses
     const email = commit.author.email || commit.committer.email
     if (!(validator.validate(email))) {
       commitInfo.message = `${email} is not a valid email address.`
@@ -51,36 +52,105 @@ module.exports = async function (commits, isRequiredFor, prURL, allowRemediation
     if (signoffs.length === 1) {
       // commit contains one signoff
       const sig = signoffs[0]
-      if (!(authors.includes(sig.name.toLowerCase())) || !(emails.includes(sig.email.toLowerCase()))) {
-        commitInfo.message = `Expected "${commit.author.name} <${commit.author.email}>", but got "${sig.name} <${sig.email}>".`
-        failed.push(commitInfo)
+      // if the signoff is an explicit match or an individual remediation, check if signoff name and email match the commit
+      // if the signoff is from a third-party remediation and passed the tests in getSignoffs, it is valid
+      if ((['explicit','individualRemediation'].includes(sig.type)) &&   
+        (!(authors.includes(sig.name.toLowerCase())) ||
+        !(emails.includes(sig.email.toLowerCase())))) {
+	      commitInfo.message = `Expected "${commit.author.name} <${commit.author.email}>", but got "${sig.name} <${sig.email}>".`
+    	  failed.push(commitInfo)
       }
     } else {
       // commit contains multiple signoffs
+      // first, find explicit signoffs which match the author exactly
       const valid = signoffs.filter(
-        signoff => authors.includes(signoff.name.toLowerCase()) && emails.includes(signoff.email.toLowerCase())
+        signoff => authors.includes(signoff.name.toLowerCase()) && emails.includes(signoff.email.toLowerCase()) && (signoff.type === 'explicit')
       )
+      // next, find individual remediations which match the author exactly
+      const validIndividualRemediation = signoffs.filter(
+      	signoff => authors.includes(signoff.name.toLowerCase()) && emails.includes(signoff.email.toLowerCase()) && (signoff.type === 'individualRemediation')
+      )
+      // if the signoff is from a third-party remediation and passed the tests in getSignoffs, it is valid
+      const validThirdPartyRemediation = signoffs.filter(
+        signoff => signoff.type === 'thirdPartyRemediation')
 
-      if (valid.length === 0) {
+      // fail if no signoffs of any type match author's name and email
+      if ((valid.length === 0) && (validIndividualRemediation.length === 0) && (validThirdPartyRemediation.length === 0)) {
         const got = signoffs.map(sig => `"${sig.name} <${sig.email}>"`).join(', ')
         commitInfo.message = `Can not find "${commit.author.name} <${commit.author.email}>", in [${got}].`
         failed.push(commitInfo)
       }
     } // end if
   } // end for
-  return failed
+  if (failed) {
+    return failed.sort((a,b) => a.author.localeCompare(b.author))
+  } else {
+    return []
+  }
 }
 
-function getSignoffs (commit) {
+function getSignoffs (comparisonCommit,comparisonSha,allCommits,allowRemediationCommits) {
   const regex = /^Signed-off-by: (.*) <(.*)>\s*$/img
   const matches = []
   let match
-  while ((match = regex.exec(commit.message)) !== null) {
+  while ((match = regex.exec(comparisonCommit.message)) !== null) {
     matches.push({
       name: match[1],
-      email: match[2]
+      email: match[2],
+      type: 'explicit'
     })
   }
+
+  if (allowRemediationCommits.individual) {
+    // if individual remediation commits are allowed, look for one in the PR with a matching sha
+
+    for (const { commit, author, parents, sha } of allCommits) {
+
+      let remediationMatch
+
+      // if individual commits are allowed, look for one in the PR with a matching sha
+      const remediationRegexIndividual = /^I, (.*) <(.*)>, hereby add my Signed-off-by to this commit: (.*)\s*$/img
+      while ((remediationMatch = remediationRegexIndividual.exec(commit.message)) !== null) {
+
+        // make sure the commit author matches the author being Signed-off-by for
+        if ((remediationMatch[3] === comparisonSha) && 
+           (comparisonCommit.author.name.toLowerCase() === commit.author.name.toLowerCase()) &&
+           (comparisonCommit.author.name.toLowerCase() === remediationMatch[1].toLowerCase()) &&
+           (comparisonCommit.author.email.toLowerCase() === commit.author.email.toLowerCase()) &&
+           (comparisonCommit.author.email.toLowerCase() === remediationMatch[2].toLowerCase())) {
+          matches.push({
+            name: remediationMatch[1],
+            email: remediationMatch[2],
+            type: 'individualRemediation'
+          })
+        } // end if
+      } // end while
+
+      if (allowRemediationCommits.thirdParty) {
+
+        // if 3rd party commits are allowed, look for one in the PR with a matching sha
+        let remediationRegexThirdParty =  /^On behalf of (.*) <(.*)>, I, (.*) <(.*)>, hereby add my Signed-off-by to this commit: (.*)\s*$/img
+        while ((remediationMatch = remediationRegexThirdParty.exec(commit.message)) !== null) {
+          // make sure the commit author or committer matches the person claiming to do the third-party remediation, and that the signoff matches the original failing commit
+
+          if ((remediationMatch[5] === comparisonSha) &&
+             (comparisonCommit.author.name.toLowerCase() === remediationMatch[1].toLowerCase()) &&
+             (comparisonCommit.author.email.toLowerCase() === remediationMatch[2].toLowerCase()) &&
+             (((commit.author.name.toLowerCase() === remediationMatch[3].toLowerCase()) &&
+             (commit.author.email.toLowerCase() === remediationMatch[4].toLowerCase())) || 
+             ((commit.committer.name.toLowerCase() === remediationMatch[3].toLowerCase()) &&
+             (commit.committer.email.toLowerCase() === remediationMatch[4].toLowerCase())))) {
+
+            matches.push({
+              name: remediationMatch[1],
+              email: remediationMatch[2],
+              type: 'thirdPartyRemediation'
+            })
+          } // end if
+        } // end while
+      } // end if
+    } // end if
+  } //end if
 
   return matches
 }

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -24,14 +24,36 @@ Object {
   "head_sha": "e76ed6025cec8879c75454a6efd6081d46de4c94",
   "name": "DCO",
   "output": Object {
-    "summary": "You only have one commit incorrectly signed off! To fix, first ensure you have a local copy of your branch by [checking out the pull request locally via command line](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally). Next, head to your local branch and run: 
-\`\`\`bash
-git commit --amend --no-edit --signoff
-\`\`\`
-Now your commits will have your sign off. Next run 
-\`\`\`bash
-git push --force-with-lease origin dco-test
-\`\`\`
+    "summary": "There is one commit incorrectly signed off.  This means that the author of this commit failed to include a Signed-off-by line in the commit message.
+
+To avoid having PRs blocked in the future, always include \`Signed-off-by: Author Name <authoremail@example.com>\` in *every* commit message. You can also do this automatically by using the -s flag (i.e., \`git commit -s\`).
+
+Here is how to fix the problem so that this code can be merged.
+
+
+---
+
+### Rebase the branch
+
+If you have a local git environment and meet the criteria below, one option is to rebase the branch and add your Signed-off-by lines in the new commits.  Please note that if others have already begun work based upon the commits in this branch, this solution will rewrite history and may cause serious issues for collaborators ([described in the git documentation](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) under \\"The Perils of Rebasing\\").
+
+You should only do this if:
+
+* You are the only author of the commits in this branch
+* You are absolutely certain nobody else is doing any work based upon this branch
+* There are no empty commits in the branch (for example, a DCO Remediation Commit which was added using \`--allow-empty\`)
+
+To add your Signed-off-by line to every commit in this branch:
+
+1. Ensure you have a local copy of your branch by [checking out the pull request locally via command line](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally).
+1. In your local branch, run: \`git rebase HEAD~1 --signoff\`
+1. Force push your changes to overwrite the branch: \`git push --force-with-lease origin dco-test\`
+
+---
+
+
+
+### Summary
 
 Commit sha: [e76ed60](https://github.com/robotland/test/pull/113/commits/e76ed6025cec8879c75454a6efd6081d46de4c94), Author: Brandon Keepers, Committer: GitHub; The sign-off is missing.",
     "title": "DCO",
@@ -56,14 +78,36 @@ Object {
   "head_sha": "34c5c7793cb3b279e22454cb6750c80560547b3a",
   "name": "DCO",
   "output": Object {
-    "summary": "You only have one commit incorrectly signed off! To fix, first ensure you have a local copy of your branch by [checking out the pull request locally via command line](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally). Next, head to your local branch and run: 
-\`\`\`bash
-git commit --amend --no-edit --signoff
-\`\`\`
-Now your commits will have your sign off. Next run 
-\`\`\`bash
-git push --force-with-lease origin changes
-\`\`\`
+    "summary": "There is one commit incorrectly signed off.  This means that the author of this commit failed to include a Signed-off-by line in the commit message.
+
+To avoid having PRs blocked in the future, always include \`Signed-off-by: Author Name <authoremail@example.com>\` in *every* commit message. You can also do this automatically by using the -s flag (i.e., \`git commit -s\`).
+
+Here is how to fix the problem so that this code can be merged.
+
+
+---
+
+### Rebase the branch
+
+If you have a local git environment and meet the criteria below, one option is to rebase the branch and add your Signed-off-by lines in the new commits.  Please note that if others have already begun work based upon the commits in this branch, this solution will rewrite history and may cause serious issues for collaborators ([described in the git documentation](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) under \\"The Perils of Rebasing\\").
+
+You should only do this if:
+
+* You are the only author of the commits in this branch
+* You are absolutely certain nobody else is doing any work based upon this branch
+* There are no empty commits in the branch (for example, a DCO Remediation Commit which was added using \`--allow-empty\`)
+
+To add your Signed-off-by line to every commit in this branch:
+
+1. Ensure you have a local copy of your branch by [checking out the pull request locally via command line](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally).
+1. In your local branch, run: \`git rebase HEAD~1 --signoff\`
+1. Force push your changes to overwrite the branch: \`git push --force-with-lease origin changes\`
+
+---
+
+
+
+### Summary
 
 Commit sha: [6dcb09b](https://github.com/octocat/Hello-World/pull/1/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e), Author: Monalisa Octocat, Committer: Monalisa Octocat; The sign-off is missing.",
     "title": "DCO",

--- a/test/dco.test.js
+++ b/test/dco.test.js
@@ -1,517 +1,1397 @@
+/*
+* The tests in this file verify the functionality of Probot DCO. Because there are many ways to
+* write a signoff and many ways to misconfigure git, the goal is to flush out as many corner cases
+* as possible.
+*
+* If you are adding a new feature, please note that you might need to repeat your test a few times
+* to verify that functionality is unchanged when various config options are enabled.
+*
+* Usage (from root directory): ./node_modules/jest/bin/jest.js
+* To see a list of tests: ./node_modules/jest/bin/jest.js --verbose
+*/
+
 const getDCOStatus = require('../lib/dco.js')
 
 const success = []
-const sha = '18aebfa67dde85da0f5099ad70ef647685a05205'
+const shaA = '18aebfa67dde85da0f5099ad70ef647685a05205'
+const shaB = 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+const shaC = '966587f0902920ed656950b0766e1073f8a532c0'
 const alwaysRequireSignoff = async () => true
 const dontRequireSignoffFor = (allowedLogin) => async (login) => { return login !== allowedLogin }
 const prInfo = 'https://github.com/hiimbex/testing-things/pull/1'
 
-describe('dco', () => {
-  test('returns true if message contains signoff', async () => {
-    const commit = {
-      message: 'Hello world\n\nSigned-off-by: Brandon Keepers <bkeepers@github.com>',
-      author: {
-        name: 'Brandon Keepers',
-        email: 'bkeepers@github.com'
-      },
-      committer: {
-        name: 'Bex Warner',
-        email: 'bexmwarner@gmail.com'
-      }
-    }
-    const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
+describe('EXPLICIT DCO SIGN-OFFS', () => {
+/*
+* The tests in this section verify Probot DCO's default behavior, whereby an author or
+* committer signs off explicitly on each commit. Merge commits and commits from bots and
+* verified org members are ignored.
+*/
 
-    expect(dcoObject).toEqual(success)
+  describe('Single commit', () => {
+
+    describe('Success patterns', () => {
+
+      test('Single commit is correctly signed-off', async () => {
+        const commit = {
+          message: 'Hello world\n\nSigned-off-by: Brandon Keepers <bkeepers@github.com>',
+          author: {
+            name: 'Brandon Keepers',
+            email: 'bkeepers@github.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('Single commit is correctly signed-off by one of multiple sign-offs (correct sign-off first)', async () => {
+        const commit = {
+          message: 'Hello world\n\n' +
+            'Signed-off-by: Brandon Keepers <bkeepers@github.com>\n' +
+            'Signed-off-by: Unknown <tester@github.com>',
+          author: {
+            name: 'Brandon Keepers',
+            email: 'bkeepers@github.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('Single commit is correctly signed-off by one of multiple sign-offs (correct sign-off second)', async () => {
+        const commit = {
+          message: 'Hello world\n\n' +
+            'Signed-off-by: Unknown <tester@github.com>\n' +
+            'Signed-off-by: Brandon Keepers <bkeepers@github.com>',
+          author: {
+            name: 'Brandon Keepers',
+            email: 'bkeepers@github.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('Single commit is correctly signed-off with case-insensitive "signed-off-by:"', async () => {
+        const commit = {
+          message: 'signed off correctly\n\nsigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'hiimbex',
+            email: 'hiimbex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('Single commit is correctly signed-off with case-insensitive author and email', async () => {
+        const commit = {
+          message: 'cAsInG iS fUn\n\nsigned-off-by: HiImBeXo <HiImBeX@bExO.cOm>',
+          author: {
+            name: 'hiimbexo',
+            email: 'hiimbex@bexo.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('Single commit is correctly signed-off with multiple trailing newlines', async () => {
+        const commit = {
+          message: 'signed off correctly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>\n\n',
+          author: {
+            name: 'hiimbex',
+            email: 'hiimbex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('Single commit is correctly signed-off with trailing whitespace', async () => {
+        const commit = {
+          message: 'signed off correctly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>			',
+          author: {
+            name: 'hiimbex',
+            email: 'hiimbex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('Single commit is correctly signed-off with email containing subdomains', async () => {
+        const commit = {
+          message: 'signed off correctly\n\nsigned-off-by: hiimbex <hiimbex@sub.disney.com>\n\n',
+          author: {
+            name: 'hiimbex',
+            email: 'hiimbex@sub.disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('Single commit is correctly signed-off with email containing plus aliasing', async () => {
+        const commit = {
+          message: 'signed off correctly\n\nsigned-off-by: hiimbex <hiimbex+alias@disney.com>\n\n',
+          author: {
+            name: 'hiimbex',
+            email: 'hiimbex+alias@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('Single commit has valid sign-off from committer, not author', async () => {
+        const commit = {
+          message: 'What a nice day!\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+          author: {
+            name: 'Bexo',
+            email: 'bexo@gmail.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('Single commit is correctly signed-off by committer, author does not exist', async () => {
+        const commit = {
+          message: 'What a nice day!\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+          author: {
+            name: 'Bexo',
+            email: 'bexo@gmail.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const author = null
+        const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('Single commit is correctly signed-off, author does not exist', async () => {
+        const commit = {
+          message: 'What a nice day!\n\nSigned-off-by: Bexo <bexo@gmail.com>',
+          author: {
+            name: 'Bexo',
+            email: 'bexo@gmail.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const author = null
+        const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('Single commit is a merge commit, no sign-off', async () => {
+        const commit = {
+          message: 'mergin stuff',
+          author: {
+            name: 'Brandon Keepers',
+            email: 'bkeepers@github.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [1, 2], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('Single commit is from a bot, no sign-off', async () => {
+        const commit = {
+          message: 'I aM rObOt I dO wHaT i PlEaSe.',
+          author: {
+            name: 'bexobot [bot]',
+            email: 'wut'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const author = {
+          login: 'bexobot [bot]',
+          type: 'Bot'
+        }
+        const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('Single verified commit is from an org member, no sign-off', async () => {
+        const commit = {
+          message: 'yolo',
+          author: {
+            name: 'Lorant Pinter',
+            email: 'lorant.pinter@gmail.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          },
+          verification: {
+            verified: true
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA}], dontRequireSignoffFor('lptr'), prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+    })
+
+    describe('Failure patterns:', () => {
+
+      test('Single commit does not contain a sign-off', async () => {
+        const commit = {
+          message: 'yolo',
+          author: {
+            name: 'Brandon Keepers',
+            email: 'bkeepers@github.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'Brandon Keepers',
+          email: 'bkeepers@github.com',
+          committer: 'Bex Warner',
+          message: 'The sign-off is missing.',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single commit does not contain a sign-off, author does not exist', async () => {
+        const commit = {
+          message: 'What a nice day!',
+          author: {
+            name: 'Bexo',
+            email: 'bexo@gmail.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const author = null
+        const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'Bexo',
+          email: 'bexo@gmail.com',
+          committer: 'Bex Warner',
+          message: 'The sign-off is missing.',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single commit contains multiple sign-offs, and none are correct', async () => {
+        const commit = {
+          message: 'Hello world\n\n' +
+            'Signed-off-by: Tester1 <tester1@github.com>\n' +
+            'Signed-off-by: Tester2 <tester2@github.com>',
+          author: {
+            name: 'Author Name',
+            email: 'author@email.com'
+          },
+          committer: {
+            name: 'Committer Name',
+            email: 'committer@email.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          'author': 'Author Name',
+          'email': 'author@email.com',
+          'committer': 'Committer Name',
+          'message': 'Can not find "Author Name <author@email.com>", in ["Tester1 <tester1@github.com>", "Tester2 <tester2@github.com>"].',
+          'sha': '18aebfa67dde85da0f5099ad70ef647685a05205',
+          'url': 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single commit contains a sign-off with incorrect name.', async () => {
+        const commit = {
+          message: 'signed off by wrong author\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'hiimbex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'hiimbex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "hiimbex <bex@disney.com>", but got "bex <bex@disney.com>".',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single commit contains a sign-off with incorrect email', async () => {
+        const commit = {
+          message: 'signed off by wrong author\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'hiimbex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'bex',
+          email: 'hiimbex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <hiimbex@disney.com>", but got "bex <bex@disney.com>".',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single commit contains a sign-off with incorrect name and email', async () => {
+        const commit = {
+          message: 'signed off by wrong author\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single commit is correctly signed-off with whitespace around name', async () => {
+        const commit = {
+          message: 'Hello world\n\nSigned-off-by:   Brandon Keepers  <bkeepers@github.com>',
+          author: {
+            name: 'Brandon Keepers',
+            email: 'bkeepers@github.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'Brandon Keepers',
+          email: 'bkeepers@github.com',
+          committer: 'Bex Warner',
+          message: 'Expected "Brandon Keepers <bkeepers@github.com>", but got "  Brandon Keepers  <bkeepers@github.com>".',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single commit is correctly signed-off with whitespace around email', async () => {
+        const commit = {
+          message: 'Hello world\n\nSigned-off-by: Brandon Keepers < bkeepers@github.com >',
+          author: {
+            name: 'Brandon Keepers',
+            email: 'bkeepers@github.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'Brandon Keepers',
+          email: 'bkeepers@github.com',
+          committer: 'Bex Warner',
+          message: 'Expected "Brandon Keepers <bkeepers@github.com>", but got "Brandon Keepers < bkeepers@github.com >".',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single commit has "Signed-off-by:" text but name is missing', async () => {
+        const commit = {
+          message: 'bad signoff\n\nsigned-off-by: <hiimbex@disney.com>',
+          author: {
+            name: 'hiimbex',
+            email: 'hiimbex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'hiimbex',
+          email: 'hiimbex@disney.com',
+          committer: 'Bex Warner',
+          message: 'The sign-off is missing.',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single commit has "Signed-off-by:" text but email is missing', async () => {
+        const commit = {
+          message: 'bad signoff\n\nsigned-off-by: hiimbex',
+          author: {
+            name: 'hiimbex',
+            email: 'hiimbex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'hiimbex',
+          email: 'hiimbex@disney.com',
+          committer: 'Bex Warner',
+          message: 'The sign-off is missing.',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single commit has "Signed-off-by:" text but email is missing angle brackets', async () => {
+        const commit = {
+          message: 'bad signoff\n\nsigned-off-by: hiimbex hiimbex@disney.com',
+          author: {
+            name: 'hiimbex',
+            email: 'hiimbex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'hiimbex',
+          email: 'hiimbex@disney.com',
+          committer: 'Bex Warner',
+          message: 'The sign-off is missing.',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single commit has "Signed-off-by:" text but name and email are missing', async () => {
+        const commit = {
+          message: 'bad signoff\n\nsigned-off-by: ',
+          author: {
+            name: 'hiimbex',
+            email: 'hiimbex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'hiimbex',
+          email: 'hiimbex@disney.com',
+          committer: 'Bex Warner',
+          message: 'The sign-off is missing.',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single commit has "Signed-off-by:" text but name and email are swapped', async () => {
+        const commit = {
+          message: 'bad signoff\n\nsigned-off-by: hiimbex@disney.com <hiimbex>',
+          author: {
+            name: 'hiimbex',
+            email: 'hiimbex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'hiimbex',
+          email: 'hiimbex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "hiimbex <hiimbex@disney.com>", but got "hiimbex@disney.com <hiimbex>".',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single commit has "Signed-off-by:" text but email is invalid (missing @)', async () => {
+        const commit = {
+          message: 'bad email\n\nsigned-off-by: hiimbex <hiimbex(at)disney.com>',
+          author: {
+            name: 'hiimbex',
+            email: 'hiimbex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'hiimbex',
+          email: 'hiimbex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "hiimbex <hiimbex@disney.com>", but got "hiimbex <hiimbex(at)disney.com>".',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single commit has "Signed-off-by:" text but email is invalid (missing TLD)', async () => {
+        const commit = {
+          message: 'bad email\n\nsigned-off-by: hiimbex <hiimbex@bexo>',
+          author: {
+            name: 'hiimbex',
+            email: 'hiimbex@bexo'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'hiimbex',
+          email: 'hiimbex@bexo',
+          committer: 'Bex Warner',
+          message: 'hiimbex@bexo is not a valid email address.',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single commit is signed-off with email containing plus aliasing, but author does not use plus aliasing', async () => {
+        const commit = {
+          message: 'signed off correctly\n\nsigned-off-by: hiimbex <hiimbex+alias@disney.com>\n\n',
+          author: {
+            name: 'hiimbex',
+            email: 'hiimbex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'hiimbex',
+          email: 'hiimbex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "hiimbex <hiimbex@disney.com>", but got "hiimbex <hiimbex+alias@disney.com>".',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('Single unverified commit is from an org member, no sign-off', async () => {
+        const commit = {
+          message: 'yolo',
+          author: {
+            name: 'Lorant Pinter',
+            email: 'lorant.pinter@gmail.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          },
+          verification: {
+            verified: false
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA}], dontRequireSignoffFor('lptr'), prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'Lorant Pinter',
+          email: 'lorant.pinter@gmail.com',
+          committer: 'Bex Warner',
+          message: 'Commit by organization member is not verified.',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+    })
   })
 
-  test('returns true if message contains multiple signoffs including valid', async () => {
-    const commit = {
-      message: 'Hello world\n\n' +
-        'Signed-off-by: Unknown <tester@github.com>\n' +
-        'Signed-off-by: Brandon Keepers <bkeepers@github.com>',
-      author: {
-        name: 'Brandon Keepers',
-        email: 'bkeepers@github.com'
-      },
-      committer: {
-        name: 'Bex Warner',
-        email: 'bexmwarner@gmail.com'
-      }
-    }
-    const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
+  describe('Two commits', () => {
 
-    expect(dcoObject).toEqual(success)
+    describe('Success patterns', () => {
+
+      test('First commit is correctly signed-off; second commit is correctly signed-off', async () => {
+        const commitA = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('First commit is correctly signed-off by one of multiple sign-offs; second commit is correctly signed-off', async () => {
+        const commitA = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>\nSigned-off-by: Brian Warner <brian@bdwarner.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('First commit is correctly signed-off; second commit is correctly signed-off by one of multiple sign-offs', async () => {
+        const commitA = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>\nSigned-off-by: Brian Warner <brian@bdwarner.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('First commit is correctly signed-off by one of multiple sign-offs; second commit is correctly signed-off by one of multiple sign-offs', async () => {
+        const commitA = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>\nSigned-off-by: Brian Warner <brian@bdwarner.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>\nSigned-off-by: Brian Warner <brian@bdwarner.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+    })
+
+    describe('Failure patterns', () => {
+
+      test('First commit does not contain a sign-off; second commit is correctly signed-off', async () => {
+        const commitA = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('First commit is correctly signed-off, second commit does not contain a sign-off', async () => {
+        const commitA = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+        }])
+      })
+
+      test('First commit is incorrectly signed-off, second commit does not contain a sign-off', async () => {
+        const commitA = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          },{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+            sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+        }])
+      })
+    })
   })
 
-  test('returns false if message does not contain valid signoff in multiple signoffs', async () => {
-    const commit = {
-      message: 'Hello world\n\n' +
-        'Signed-off-by: Tester1 <tester1@github.com>\n' +
-        'Signed-off-by: Tester2 <tester2@github.com>',
-      author: {
-        name: 'Author Name',
-        email: 'author@email.com'
-      },
-      committer: {
-        name: 'Committer Name',
-        email: 'committer@email.com'
-      }
-    }
-    const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
+  describe('Three commits', () => {
 
-    expect(dcoObject).toEqual([{
-      author: 'Author Name',
-      committer: 'Committer Name',
-      message: 'Can not find "Author Name <author@email.com>", in ["Tester1 <tester1@github.com>", "Tester2 <tester2@github.com>"].',
-      sha: '18aebfa67dde85da0f5099ad70ef647685a05205',
-      url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205'
-    }])
+    describe('Success patterns', () => {
+
+      test('First commit is correctly signed-off; second commit is correctly signed-off; third commit is correctly signed-off', async () => {
+        const commitA = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitC = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+
+      test('First commit is correctly signed-off; second commit is correctly signed-off by one of multiple sign-offs; third commit is correctly signed-off', async () => {
+        const commitA = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>\nSigned-off-by: Brian Warner <brian@bdwarner.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitC = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual(success)
+      })
+    })
+
+    describe('Failure patterns', () => {
+
+      test('First commit is incorrectly signed-off; second commit is correctly signed-off; third commit is correctly signed-off', async () => {
+        const commitA = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitC = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('First commit is correctly signed-off; second commit is incorrectly signed-off; third commit is correctly signed-off', async () => {
+        const commitA = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitC = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+        }])
+      })
+
+      test('First commit is correctly signed-off; second commit is correctly signed-off; third commit is incorrectly signed-off', async () => {
+        const commitA = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitC = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: '966587f0902920ed656950b0766e1073f8a532c0'
+        }])
+      })
+
+      test('First commit is incorrectly signed-off; second commit is incorrectly signed-off; third commit is correctly signed-off', async () => {
+        const commitA = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitC = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          },{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+            sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+        }])
+      })
+
+      test('First commit is correctly signed-off; second commit is incorrectly signed-off; third commit is incorrectly signed-off', async () => {
+        const commitA = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitC = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+            sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+          },{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+            sha: '966587f0902920ed656950b0766e1073f8a532c0'
+        }])
+      })
+
+      test('First commit is incorrectly signed-off; second commit is correctly signed-off; third commit is incorrectly signed-off', async () => {
+        const commitA = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitC = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          },{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+            sha: '966587f0902920ed656950b0766e1073f8a532c0'
+        }])
+      })
+
+      test('First commit is incorrectly signed-off; second commit is incorrectly signed-off; third commit is incorrectly signed-off', async () => {
+        const commitA = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitC = {
+          message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          },{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+            sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+          },{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+            sha: '966587f0902920ed656950b0766e1073f8a532c0'
+        }])
+      })
+    })
   })
-
-  test('returns true for merge commit', async () => {
-    const commit = {
-      message: 'mergin stuff',
-      author: {
-        name: 'Brandon Keepers',
-        email: 'bkeepers@github.com'
-      },
-      committer: {
-        name: 'Bex Warner',
-        email: 'bexmwarner@gmail.com'
-      }
-    }
-    const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [1, 2], sha }], alwaysRequireSignoff, prInfo)
-
-    expect(dcoObject).toEqual(success)
-  })
-
-  test('returns error message if message does not have signoff', async () => {
-    const commit = {
-      message: 'yolo',
-      author: {
-        name: 'Brandon Keepers',
-        email: 'bkeepers@github.com'
-      },
-      committer: {
-        name: 'Bex Warner',
-        email: 'bexmwarner@gmail.com'
-      }
-    }
-    const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
-
-    expect(dcoObject).toEqual([{
-      url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-      author: 'Brandon Keepers',
-      committer: 'Bex Warner',
-      message: 'The sign-off is missing.',
-      sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-    }])
-  })
-
-  test(
-    'returns error message if the signoff does not match the author',
-    async () => {
-      const commit = {
-        message: 'signed off by wrong author\n\nSigned-off-by: bex <bex@disney.com>',
-        author: {
-          name: 'hiimbex',
-          email: 'bex@disney.com'
-        },
-        committer: {
-          name: 'Bex Warner',
-          email: 'bexmwarner@gmail.com'
-        }
-      }
-      const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
-
-      expect(dcoObject).toEqual([{
-        url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-        author: 'hiimbex',
-        committer: 'Bex Warner',
-        message: 'Expected "hiimbex <bex@disney.com>", but got "bex <bex@disney.com>".',
-        sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-      }])
-    }
-  )
-
-  test(
-    'returns error message if the signoff does not match the email',
-    async () => {
-      const commit = {
-        message: 'signed off by wrong author\n\nSigned-off-by: bex <bex@disney.com>',
-        author: {
-          name: 'bex',
-          email: 'hiimbex@disney.com'
-        },
-        committer: {
-          name: 'Bex Warner',
-          email: 'bexmwarner@gmail.com'
-        }
-      }
-      const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
-
-      expect(dcoObject).toEqual([{
-        url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-        author: 'bex',
-        committer: 'Bex Warner',
-        message: 'Expected "bex <hiimbex@disney.com>", but got "bex <bex@disney.com>".',
-        sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-      }])
-    }
-  )
-
-  test(
-    'returns error message if the signoff does not match the author or email',
-    async () => {
-      const commit = {
-        message: 'signed off by wrong author\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
-        author: {
-          name: 'bex',
-          email: 'bex@disney.com'
-        },
-        committer: {
-          name: 'Bex Warner',
-          email: 'bexmwarner@gmail.com'
-        }
-      }
-      const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
-
-      expect(dcoObject).toEqual([{
-        url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-        author: 'bex',
-        committer: 'Bex Warner',
-        message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-        sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-      }])
-    }
-  )
-
-  test(
-    'returns error message if the first commit has no sign off but the second commit has a sign off',
-    async () => {
-      const commitA = {
-        message: 'signed off by wrong author\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
-        author: {
-          name: 'bex',
-          email: 'bex@disney.com'
-        },
-        committer: {
-          name: 'Bex Warner',
-          email: 'bexmwarner@gmail.com'
-        }
-      }
-      const commitB = {
-        message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
-        author: {
-          name: 'bex',
-          email: 'bex@disney.com'
-        },
-        committer: {
-          name: 'Bex Warner',
-          email: 'bexmwarner@gmail.com'
-        }
-      }
-      const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
-
-      expect(dcoObject).toEqual([{
-        url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-        author: 'bex',
-        committer: 'Bex Warner',
-        message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-        sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-      }])
-    }
-  )
-
-  test(
-    'returns error message if the first commit has a sign off but the second commit does not have a sign off',
-    async () => {
-      const commitA = {
-        message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
-        author: {
-          name: 'bex',
-          email: 'bex@disney.com'
-        },
-        committer: {
-          name: 'Bex Warner',
-          email: 'bexmwarner@gmail.com'
-        }
-      }
-      const commitB = {
-        message: 'signed off by wrong author\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
-        author: {
-          name: 'bex',
-          email: 'bex@disney.com'
-        },
-        committer: {
-          name: 'Bex Warner',
-          email: 'bexmwarner@gmail.com'
-        }
-      }
-      const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
-
-      expect(dcoObject).toEqual([{
-        url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-        author: 'bex',
-        committer: 'Bex Warner',
-        message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-        sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-      }])
-    }
-  )
-
-  test('returns success if all commits have sign off', async () => {
-    const commitA = {
-      message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
-      author: {
-        name: 'bex',
-        email: 'bex@disney.com'
-      },
-      committer: {
-        name: 'Bex Warner',
-        email: 'bexmwarner@gmail.com'
-      }
-    }
-    const commitB = {
-      message: 'signed off by wrong author\n\nSigned-off-by: bex <bex@disney.com>',
-      author: {
-        name: 'bex',
-        email: 'bex@disney.com'
-      },
-      committer: {
-        name: 'Bex Warner',
-        email: 'bexmwarner@gmail.com'
-      }
-    }
-    const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
-
-    expect(dcoObject).toEqual(success)
-  })
-
-  test(
-    'returns success when casing in sign of message is different',
-    async () => {
-      const commit = {
-        message: 'signed off correctly\n\nsigned-off-by: hiimbex <hiimbex@disney.com>',
-        author: {
-          name: 'hiimbex',
-          email: 'hiimbex@disney.com'
-        },
-        committer: {
-          name: 'Bex Warner',
-          email: 'bexmwarner@gmail.com'
-        }
-      }
-      const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
-
-      expect(dcoObject).toEqual(success)
-    }
-  )
-
-  test('returns failure when email is invalid', async () => {
-    const commit = {
-      message: 'bad email\n\nsigned-off-by: hiimbex <hiimbex@bexo>',
-      author: {
-        name: 'hiimbex',
-        email: 'hiimbex@bexo'
-      },
-      committer: {
-        name: 'Bex Warner',
-        email: 'bexmwarner@gmail.com'
-      }
-    }
-    const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
-
-    expect(dcoObject).toEqual([{
-      url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-      author: 'hiimbex',
-      committer: 'Bex Warner',
-      message: 'hiimbex@bexo is not a valid email address.',
-      sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-    }])
-  })
-
-  test('returns success when email and name are differently cased (case-insensitivity)', async () => {
-    const commit = {
-      message: 'cAsInG iS fUn\n\nsigned-off-by: HiImBeXo <HiImBeX@bExO.cOm>',
-      author: {
-        name: 'hiimbexo',
-        email: 'hiimbex@bexo.com'
-      },
-      committer: {
-        name: 'Bex Warner',
-        email: 'bexmwarner@gmail.com'
-      }
-    }
-    const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
-
-    expect(dcoObject).toEqual(success)
-  })
-
-  test('returns success when committer is bot', async () => {
-    const commit = {
-      message: 'I aM rObOt I dO wHaT i PlEaSe.',
-      author: {
-        name: 'bexobot [bot]',
-        email: 'wut'
-      },
-      committer: {
-        name: 'Bex Warner',
-        email: 'bexmwarner@gmail.com'
-      }
-    }
-    const author = {
-      login: 'bexobot [bot]',
-      type: 'Bot'
-    }
-    const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha }], alwaysRequireSignoff, prInfo)
-
-    expect(dcoObject).toEqual(success)
-  })
-
-  test(
-    'returns success if verified commit without sign off is from org member',
-    async () => {
-      const commit = {
-        message: 'yolo',
-        author: {
-          name: 'Lorant Pinter',
-          email: 'lorant.pinter@gmail.com'
-        },
-        committer: {
-          name: 'Bex Warner',
-          email: 'bexmwarner@gmail.com'
-        },
-        verification: {
-          verified: true
-        }
-      }
-      const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha }], dontRequireSignoffFor('lptr'), prInfo)
-
-      expect(dcoObject).toEqual(success)
-    }
-  )
-
-  test(
-    'returns failure if unverified commit without sign off is from org member',
-    async () => {
-      const commit = {
-        message: 'yolo',
-        author: {
-          name: 'Lorant Pinter',
-          email: 'lorant.pinter@gmail.com'
-        },
-        committer: {
-          name: 'Bex Warner',
-          email: 'bexmwarner@gmail.com'
-        },
-        verification: {
-          verified: false
-        }
-      }
-      const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha }], dontRequireSignoffFor('lptr'), prInfo)
-
-      expect(dcoObject).toEqual([{
-        url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-        author: 'Lorant Pinter',
-        committer: 'Bex Warner',
-        message: 'Commit by organization member is not verified.',
-        sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-      }])
-    }
-  )
-
-  test(
-    'returns success if commit.author is different but commit.committer matches',
-    async () => {
-      const commit = {
-        message: 'What a nice day!\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
-        author: {
-          name: 'Bexo',
-          email: 'bexo@gmail.com'
-        },
-        committer: {
-          name: 'Bex Warner',
-          email: 'bexmwarner@gmail.com'
-        }
-      }
-      const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha }], alwaysRequireSignoff, prInfo)
-
-      expect(dcoObject).toEqual(success)
-    }
-  )
-
-  test(
-    'returns success if author does not exist but everything else is ok',
-    async () => {
-      const commit = {
-        message: 'What a nice day!\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
-        author: {
-          name: 'Bexo',
-          email: 'bexo@gmail.com'
-        },
-        committer: {
-          name: 'Bex Warner',
-          email: 'bexmwarner@gmail.com'
-        }
-      }
-      const author = null
-      const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha }], alwaysRequireSignoff, prInfo)
-
-      expect(dcoObject).toEqual(success)
-    }
-  )
-
-  test('returns failure if author does not exist and there is no sign off',
-    async () => {
-      const commit = {
-        message: 'What a nice day!',
-        author: {
-          name: 'Bexo',
-          email: 'bexo@gmail.com'
-        },
-        committer: {
-          name: 'Bex Warner',
-          email: 'bexmwarner@gmail.com'
-        }
-      }
-      const author = null
-      const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha }], alwaysRequireSignoff, prInfo)
-
-      expect(dcoObject).toEqual([{
-        url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-        author: 'Bexo',
-        committer: 'Bex Warner',
-        message: 'The sign-off is missing.',
-        sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-      }])
-    }
-  )
-
-  test(
-    'returns failure if author does not exist and there is no sign off',
-    async () => {
-      const commit = {
-        message: 'What a nice day!',
-        author: {
-          name: 'Bexo',
-          email: 'bexo@gmail.com'
-        },
-        committer: {
-          name: 'Bex Warner',
-          email: 'bexmwarner@gmail.com'
-        }
-      }
-      const author = null
-      const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha }], alwaysRequireSignoff, prInfo)
-
-      expect(dcoObject).toEqual([{
-        url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-        author: 'Bexo',
-        committer: 'Bex Warner',
-        message: 'The sign-off is missing.',
-        sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-      }])
-    }
-  )
 })

--- a/test/dco.test.js
+++ b/test/dco.test.js
@@ -6,8 +6,8 @@
 * If you are adding a new feature, please note that you might need to repeat your test a few times
 * to verify that functionality is unchanged when various config options are enabled.
 *
-* Usage (from root directory): ./node_modules/jest/bin/jest.js
-* To see a list of tests: ./node_modules/jest/bin/jest.js --verbose
+* Usage (from root directory): npx jest
+* To see a list of tests: npx jest --verbose
 */
 
 const getDCOStatus = require('../lib/dco.js')

--- a/test/dco.test.js
+++ b/test/dco.test.js
@@ -1395,3 +1395,4847 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
     })
   })
 })
+
+describe('INDIVIDUAL REMEDIATION COMMITS', () => {
+
+/*
+* The tests in this section verify Probot DCO's behavior when configured to allow individual
+* remediation commits. In order to be valid, an individual remediation commit must contain
+* specific text and be provided by the original author of the commit.
+
+* Individual remediation commits must be ignored when not configured. Because third-party
+* remediation commits are a special kind of remediation, these must also be ignored when
+* individual remediation commits are not configured.
+*/
+
+  describe('Disabled (default)', () => {
+
+    describe('Failure patterns', () => {
+
+      test('First commit does not contain a sign-off; second commit contains sign-off and correct individual remediation', async () => {
+        const commitA = {
+          message: 'No signoff',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'The sign-off is missing.',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+    })
+  })
+
+  describe('Enabled via config option', () => {
+
+    describe('Verify default functionality is unchanged', () => {
+
+/*
+* The tests in this section mirror the explicit sign-off tests exactly, except individual
+* remediation is enabled. This first sequence of tests ensures that no functionality
+* changes when individual remediation commits are enabled.
+*/
+
+      describe('Single commit', () => {
+
+        describe('Success patterns', () => {
+
+          test('Single commit is correctly signed-off', async () => {
+            const commit = {
+              message: 'Hello world\n\nSigned-off-by: Brandon Keepers <bkeepers@github.com>',
+              author: {
+                name: 'Brandon Keepers',
+                email: 'bkeepers@github.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off by one of multiple sign-offs (correct sign-off first)', async () => {
+            const commit = {
+              message: 'Hello world\n\n' +
+                'Signed-off-by: Brandon Keepers <bkeepers@github.com>\n' +
+                'Signed-off-by: Unknown <tester@github.com>',
+              author: {
+                name: 'Brandon Keepers',
+                email: 'bkeepers@github.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off by one of multiple sign-offs (correct sign-off second)', async () => {
+            const commit = {
+              message: 'Hello world\n\n' +
+                'Signed-off-by: Unknown <tester@github.com>\n' +
+                'Signed-off-by: Brandon Keepers <bkeepers@github.com>',
+              author: {
+                name: 'Brandon Keepers',
+                email: 'bkeepers@github.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off with case-insensitive "signed-off-by:"', async () => {
+            const commit = {
+              message: 'signed off correctly\n\nsigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off with case-insensitive author and email', async () => {
+            const commit = {
+              message: 'cAsInG iS fUn\n\nsigned-off-by: HiImBeXo <HiImBeX@bExO.cOm>',
+              author: {
+                name: 'hiimbexo',
+                email: 'hiimbex@bexo.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off with multiple trailing newlines', async () => {
+            const commit = {
+              message: 'signed off correctly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>\n\n',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off with trailing whitespace', async () => {
+            const commit = {
+              message: 'signed off correctly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>			',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off with email containing subdomains', async () => {
+            const commit = {
+              message: 'signed off correctly\n\nsigned-off-by: hiimbex <hiimbex@sub.disney.com>\n\n',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@sub.disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off with email containing plus aliasing', async () => {
+            const commit = {
+              message: 'signed off correctly\n\nsigned-off-by: hiimbex <hiimbex+alias@disney.com>\n\n',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex+alias@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit has valid sign-off from committer, not author', async () => {
+            const commit = {
+              message: 'What a nice day!\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+              author: {
+                name: 'Bexo',
+                email: 'bexo@gmail.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off by committer, author does not exist', async () => {
+            const commit = {
+              message: 'What a nice day!\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+              author: {
+                name: 'Bexo',
+                email: 'bexo@gmail.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const author = null
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off, author does not exist', async () => {
+            const commit = {
+              message: 'What a nice day!\n\nSigned-off-by: Bexo <bexo@gmail.com>',
+              author: {
+                name: 'Bexo',
+                email: 'bexo@gmail.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const author = null
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is a merge commit, no sign-off', async () => {
+            const commit = {
+              message: 'mergin stuff',
+              author: {
+                name: 'Brandon Keepers',
+                email: 'bkeepers@github.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [1, 2], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is from a bot, no sign-off', async () => {
+            const commit = {
+              message: 'I aM rObOt I dO wHaT i PlEaSe.',
+              author: {
+                name: 'bexobot [bot]',
+                email: 'wut'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const author = {
+              login: 'bexobot [bot]',
+              type: 'Bot'
+            }
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single verified commit is from an org member, no sign-off', async () => {
+            const commit = {
+              message: 'yolo',
+              author: {
+                name: 'Lorant Pinter',
+                email: 'lorant.pinter@gmail.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              },
+              verification: {
+                verified: true
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA}], dontRequireSignoffFor('lptr'), prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+        })
+
+        describe('Failure patterns', () => {
+
+          test('Single commit does not contain a sign-off', async () => {
+            const commit = {
+              message: 'yolo',
+              author: {
+                name: 'Brandon Keepers',
+                email: 'bkeepers@github.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'Brandon Keepers',
+              email: 'bkeepers@github.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit does not contain a sign-off, author does not exist', async () => {
+            const commit = {
+              message: 'What a nice day!',
+              author: {
+                name: 'Bexo',
+                email: 'bexo@gmail.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const author = null
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'Bexo',
+              email: 'bexo@gmail.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit contains multiple sign-offs, and none are correct', async () => {
+            const commit = {
+              message: 'Hello world\n\n' +
+                'Signed-off-by: Tester1 <tester1@github.com>\n' +
+                'Signed-off-by: Tester2 <tester2@github.com>',
+              author: {
+                name: 'Author Name',
+                email: 'author@email.com'
+              },
+              committer: {
+                name: 'Committer Name',
+                email: 'committer@email.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              'author': 'Author Name',
+              'email': 'author@email.com',
+              'committer': 'Committer Name',
+              'message': 'Can not find "Author Name <author@email.com>", in ["Tester1 <tester1@github.com>", "Tester2 <tester2@github.com>"].',
+              'sha': '18aebfa67dde85da0f5099ad70ef647685a05205',
+              'url': 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit contains a sign-off with incorrect name.', async () => {
+            const commit = {
+              message: 'signed off by wrong author\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "hiimbex <bex@disney.com>", but got "bex <bex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit contains a sign-off with incorrect email', async () => {
+            const commit = {
+              message: 'signed off by wrong author\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <hiimbex@disney.com>", but got "bex <bex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit contains a sign-off with incorrect name and email', async () => {
+            const commit = {
+              message: 'signed off by wrong author\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit is correctly signed-off with whitespace around name', async () => {
+            const commit = {
+              message: 'Hello world\n\nSigned-off-by:   Brandon Keepers  <bkeepers@github.com>',
+              author: {
+                name: 'Brandon Keepers',
+                email: 'bkeepers@github.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'Brandon Keepers',
+              email: 'bkeepers@github.com',
+              committer: 'Bex Warner',
+              message: 'Expected "Brandon Keepers <bkeepers@github.com>", but got "  Brandon Keepers  <bkeepers@github.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit is correctly signed-off with whitespace around email', async () => {
+            const commit = {
+              message: 'Hello world\n\nSigned-off-by: Brandon Keepers < bkeepers@github.com >',
+              author: {
+                name: 'Brandon Keepers',
+                email: 'bkeepers@github.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'Brandon Keepers',
+              email: 'bkeepers@github.com',
+              committer: 'Bex Warner',
+              message: 'Expected "Brandon Keepers <bkeepers@github.com>", but got "Brandon Keepers < bkeepers@github.com >".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit has "Signed-off-by:" text but name is missing', async () => {
+            const commit = {
+              message: 'bad signoff\n\nsigned-off-by: <hiimbex@disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit has "Signed-off-by:" text but email is missing', async () => {
+            const commit = {
+              message: 'bad signoff\n\nsigned-off-by: hiimbex',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit has "Signed-off-by:" text but email is missing angle brackets', async () => {
+            const commit = {
+              message: 'bad signoff\n\nsigned-off-by: hiimbex hiimbex@disney.com',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit has "Signed-off-by:" text but name and email are missing', async () => {
+            const commit = {
+              message: 'bad signoff\n\nsigned-off-by: ',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit has "Signed-off-by:" text but name and email are swapped', async () => {
+            const commit = {
+              message: 'bad signoff\n\nsigned-off-by: hiimbex@disney.com <hiimbex>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "hiimbex <hiimbex@disney.com>", but got "hiimbex@disney.com <hiimbex>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit has "Signed-off-by:" text but email is invalid (missing @)', async () => {
+            const commit = {
+              message: 'bad email\n\nsigned-off-by: hiimbex <hiimbex(at)disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "hiimbex <hiimbex@disney.com>", but got "hiimbex <hiimbex(at)disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit has "Signed-off-by:" text but email is invalid (missing TLD)', async () => {
+            const commit = {
+              message: 'bad email\n\nsigned-off-by: hiimbex <hiimbex@bexo>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@bexo'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@bexo',
+              committer: 'Bex Warner',
+              message: 'hiimbex@bexo is not a valid email address.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit is signed-off with email containing plus aliasing, but author does not use plus aliasing', async () => {
+            const commit = {
+              message: 'signed off correctly\n\nsigned-off-by: hiimbex <hiimbex+alias@disney.com>\n\n',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "hiimbex <hiimbex@disney.com>", but got "hiimbex <hiimbex+alias@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single unverified commit is from an org member, no sign-off', async () => {
+            const commit = {
+              message: 'yolo',
+              author: {
+                name: 'Lorant Pinter',
+                email: 'lorant.pinter@gmail.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              },
+              verification: {
+                verified: false
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA}], dontRequireSignoffFor('lptr'), prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'Lorant Pinter',
+              email: 'lorant.pinter@gmail.com',
+              committer: 'Bex Warner',
+              message: 'Commit by organization member is not verified.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+        })
+      })
+
+      describe('Two commits', () => {
+
+        describe('Success patterns', () => {
+
+          test('First commit is correctly signed-off; second commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('First commit is correctly signed-off by one of multiple sign-offs; second commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>\nSigned-off-by: Brian Warner <brian@bdwarner.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('First commit is correctly signed-off; second commit is correctly signed-off by one of multiple sign-offs', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>\nSigned-off-by: Brian Warner <brian@bdwarner.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('First commit is correctly signed-off by one of multiple sign-offs; second commit is correctly signed-off by one of multiple sign-offs', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>\nSigned-off-by: Brian Warner <brian@bdwarner.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>\nSigned-off-by: Brian Warner <brian@bdwarner.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+        })
+
+        describe('Failure patterns:', () => {
+
+          test('First commit does not contain a sign-off; second commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('First commit is correctly signed-off, second commit does not contain a sign-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+            }])
+          })
+
+          test('First commit is incorrectly signed-off, second commit does not contain a sign-off', async () => {
+            const commitA = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+              },{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+            }])
+          })
+        })
+      })
+
+      describe('Three commits', () => {
+
+        describe('Success patterns', () => {
+
+          test('First commit is correctly signed-off; second commit is correctly signed-off; third commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('First commit is correctly signed-off; second commit is correctly signed-off by one of multiple sign-offs; third commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>\nSigned-off-by: Brian Warner <brian@bdwarner.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual(success)
+          })
+        })
+
+        describe('Failure patterns', () => {
+
+          test('First commit is incorrectly signed-off; second commit is correctly signed-off; third commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('First commit is correctly signed-off; second commit is incorrectly signed-off; third commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+            }])
+          })
+
+          test('First commit is correctly signed-off; second commit is correctly signed-off; third commit is incorrectly signed-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '966587f0902920ed656950b0766e1073f8a532c0'
+            }])
+          })
+
+          test('First commit is incorrectly signed-off; second commit is incorrectly signed-off; third commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+              },{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+            }])
+          })
+
+          test('First commit is correctly signed-off; second commit is incorrectly signed-off; third commit is incorrectly signed-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+              },{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: '966587f0902920ed656950b0766e1073f8a532c0'
+            }])
+          })
+
+          test('First commit is incorrectly signed-off; second commit is correctly signed-off; third commit is incorrectly signed-off', async () => {
+            const commitA = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+              },{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: '966587f0902920ed656950b0766e1073f8a532c0'
+            }])
+          })
+
+          test('First commit is incorrectly signed-off; second commit is incorrectly signed-off; third commit is incorrectly signed-off', async () => {
+            const commitA = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+              },{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+              },{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: '966587f0902920ed656950b0766e1073f8a532c0'
+            }])
+          })
+        })
+      })
+    })
+
+    describe('Verify individual remediations', () => {
+
+/*
+* The tests in this section verify the behavior of individual remediation.
+*/
+
+      describe('Success patterns', () => {
+
+        test('First commit does not contain a sign-off; second commit has individual remediation and sign-off', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual(success)
+        })
+
+        test('First commit has a sign-off, name incorrect; second commit has individual remediation and sign-off', async () => {
+          const commitA = {
+            message: 'Signed-off-by: hiimbex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual(success)
+        })
+
+        test('First commit has a sign-off, email incorrect; second commit has individual remediation and sign-off', async () => {
+          const commitA = {
+            message: 'Signed-off-by: bex <hiimbex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual(success)
+        })
+
+        test('First commit contains a sign-off; second commit has redundant individual remediation and sign-off', async () => {
+          const commitA = {
+            message: 'Signed-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual(success)
+        })
+
+        test('First commit contains a sign-off; second commit has individual remediation for a non-existent sha and sign-off', async () => {
+          const commitA = {
+            message: 'Signed-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 2222222222222222222222222222222222222222\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual(success)
+        })
+
+        test('First commit has no sign-off; second commit has individual remediation, no sign-off; third commit has individual remediation and is correctly signed-off', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitC = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual(success)
+        })
+
+        test('First commit has no sign-off; second commit has no sign-off; third commit has individual remediations for both and is correctly signed-off', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitC = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\nI, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual(success)
+        })
+      })
+
+      describe("Failure patterns", () => {
+
+        test('First commit has no sign-off; second commit has remediation text but no sign-off', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has remediation and sign-off from a different author name', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, hiimbex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <bex@disney.com>',
+            author: {
+              name: 'hiimbex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has remediation and sign-off from a different author email', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <hiimbex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'hiimbex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has remediation and sign-off from a different author name and email', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+            author: {
+              name: 'hiimbex',
+              email: 'hiimbex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has correct remediation but sign-off from a different author name', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <bex@disney.com>',
+            author: {
+              name: 'hiimbex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has correct remediation but sign-off from a different author email', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <hiimbex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'hiimbex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has correct remediation but sign-off from a different author name and email', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+            author: {
+              name: 'hiimbex',
+              email: 'hiimbex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has correct sign-off but remediation from a different author name', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, hiimbex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has correct sign-off but remediation from a different author email',async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has correct sign-off but remediation from a different author name and email', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has correct sign-off but remediation for a different sha', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 2222222222222222222222222222222222222222\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+      })
+    })
+  })
+})
+
+describe('THIRD PARTY REMEDIATION COMMITS', () => {
+
+/*
+* The tests in this section verify Probot DCO's behavior when configured to allow
+* third-party remediation commits. In order to be valid, a third-party remediation commit
+* must contain specific text that matches the failing commit.
+*
+* Third party remediation commits must be ignored when not configured.
+*/
+
+  describe('Disabled (default)', () => {
+
+    describe('Failure patterns', () => {
+
+      test('First commit does not contain a sign-off; second commit contains sign-off and correct third-party remediation', async () => {
+        const commitA = {
+          message: 'No signoff',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com> hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'hiimbex',
+            email: 'hiimbex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'The sign-off is missing.',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+      test('First commit does not contain a sign-off; second commit contains sign-off and correct third-party remediation; individual remediation enabled', async () => {
+        const commitA = {
+          message: 'No signoff',
+          author: {
+            name: 'bex',
+            email: 'bex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const commitB = {
+          message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com> hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+          author: {
+            name: 'hiimbex',
+            email: 'hiimbex@disney.com'
+          },
+          committer: {
+            name: 'Bex Warner',
+            email: 'bexmwarner@gmail.com'
+          }
+        }
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+        expect(dcoObject).toEqual([{
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'The sign-off is missing.',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }])
+      })
+
+    })
+  })
+
+  describe('Enabled via config option', () => {
+
+    describe('Verify default functionality is unchanged', () => {
+
+/*
+* The tests in this section mirror the explicit sign-off tests exactly, except individual
+* remediation is enabled. This first sequence of tests ensures that no functionality
+* changes when individual remediation commits are enabled.
+*/
+
+      describe('Single commit', () => {
+
+        describe('Success patterns', () => {
+
+          test('Single commit is correctly signed-off', async () => {
+            const commit = {
+              message: 'Hello world\n\nSigned-off-by: Brandon Keepers <bkeepers@github.com>',
+              author: {
+                name: 'Brandon Keepers',
+                email: 'bkeepers@github.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off by one of multiple sign-offs (correct sign-off first)', async () => {
+            const commit = {
+              message: 'Hello world\n\n' +
+                'Signed-off-by: Brandon Keepers <bkeepers@github.com>\n' +
+                'Signed-off-by: Unknown <tester@github.com>',
+              author: {
+                name: 'Brandon Keepers',
+                email: 'bkeepers@github.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off by one of multiple sign-offs (correct sign-off second)', async () => {
+            const commit = {
+              message: 'Hello world\n\n' +
+                'Signed-off-by: Unknown <tester@github.com>\n' +
+                'Signed-off-by: Brandon Keepers <bkeepers@github.com>',
+              author: {
+                name: 'Brandon Keepers',
+                email: 'bkeepers@github.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off with case-insensitive "signed-off-by:"', async () => {
+            const commit = {
+              message: 'signed off correctly\n\nsigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off with case-insensitive author and email', async () => {
+            const commit = {
+              message: 'cAsInG iS fUn\n\nsigned-off-by: HiImBeXo <HiImBeX@bExO.cOm>',
+              author: {
+                name: 'hiimbexo',
+                email: 'hiimbex@bexo.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off with multiple trailing newlines', async () => {
+            const commit = {
+              message: 'signed off correctly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>\n\n',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off with trailing whitespace', async () => {
+            const commit = {
+              message: 'signed off correctly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>			',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off with email containing subdomains', async () => {
+            const commit = {
+              message: 'signed off correctly\n\nsigned-off-by: hiimbex <hiimbex@sub.disney.com>\n\n',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@sub.disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off with email containing plus aliasing', async () => {
+            const commit = {
+              message: 'signed off correctly\n\nsigned-off-by: hiimbex <hiimbex+alias@disney.com>\n\n',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex+alias@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit has valid sign-off from committer, not author', async () => {
+            const commit = {
+              message: 'What a nice day!\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+              author: {
+                name: 'Bexo',
+                email: 'bexo@gmail.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off by committer, author does not exist', async () => {
+            const commit = {
+              message: 'What a nice day!\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+              author: {
+                name: 'Bexo',
+                email: 'bexo@gmail.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const author = null
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is correctly signed-off, author does not exist', async () => {
+            const commit = {
+              message: 'What a nice day!\n\nSigned-off-by: Bexo <bexo@gmail.com>',
+              author: {
+                name: 'Bexo',
+                email: 'bexo@gmail.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const author = null
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is a merge commit, no sign-off', async () => {
+            const commit = {
+              message: 'mergin stuff',
+              author: {
+                name: 'Brandon Keepers',
+                email: 'bkeepers@github.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [1, 2], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single commit is from a bot, no sign-off', async () => {
+            const commit = {
+              message: 'I aM rObOt I dO wHaT i PlEaSe.',
+              author: {
+                name: 'bexobot [bot]',
+                email: 'wut'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const author = {
+              login: 'bexobot [bot]',
+              type: 'Bot'
+            }
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('Single verified commit is from an org member, no sign-off', async () => {
+            const commit = {
+              message: 'yolo',
+              author: {
+                name: 'Lorant Pinter',
+                email: 'lorant.pinter@gmail.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              },
+              verification: {
+                verified: true
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA}], dontRequireSignoffFor('lptr'), prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+        })
+
+        describe('Failure patterns', () => {
+
+          test('Single commit does not contain a sign-off', async () => {
+            const commit = {
+              message: 'yolo',
+              author: {
+                name: 'Brandon Keepers',
+                email: 'bkeepers@github.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'Brandon Keepers',
+              email: 'bkeepers@github.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit does not contain a sign-off, author does not exist', async () => {
+            const commit = {
+              message: 'What a nice day!',
+              author: {
+                name: 'Bexo',
+                email: 'bexo@gmail.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const author = null
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'Bexo',
+              email: 'bexo@gmail.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit contains multiple sign-offs, and none are correct', async () => {
+            const commit = {
+              message: 'Hello world\n\n' +
+                'Signed-off-by: Tester1 <tester1@github.com>\n' +
+                'Signed-off-by: Tester2 <tester2@github.com>',
+              author: {
+                name: 'Author Name',
+                email: 'author@email.com'
+              },
+              committer: {
+                name: 'Committer Name',
+                email: 'committer@email.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              'author': 'Author Name',
+              'email': 'author@email.com',
+              'committer': 'Committer Name',
+              'message': 'Can not find "Author Name <author@email.com>", in ["Tester1 <tester1@github.com>", "Tester2 <tester2@github.com>"].',
+              'sha': '18aebfa67dde85da0f5099ad70ef647685a05205',
+              'url': 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit contains a sign-off with incorrect name.', async () => {
+            const commit = {
+              message: 'signed off by wrong author\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "hiimbex <bex@disney.com>", but got "bex <bex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit contains a sign-off with incorrect email', async () => {
+            const commit = {
+              message: 'signed off by wrong author\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <hiimbex@disney.com>", but got "bex <bex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit contains a sign-off with incorrect name and email', async () => {
+            const commit = {
+              message: 'signed off by wrong author\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit is correctly signed-off with whitespace around name', async () => {
+            const commit = {
+              message: 'Hello world\n\nSigned-off-by:   Brandon Keepers  <bkeepers@github.com>',
+              author: {
+                name: 'Brandon Keepers',
+                email: 'bkeepers@github.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'Brandon Keepers',
+              email: 'bkeepers@github.com',
+              committer: 'Bex Warner',
+              message: 'Expected "Brandon Keepers <bkeepers@github.com>", but got "  Brandon Keepers  <bkeepers@github.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit is correctly signed-off with whitespace around email', async () => {
+            const commit = {
+              message: 'Hello world\n\nSigned-off-by: Brandon Keepers < bkeepers@github.com >',
+              author: {
+                name: 'Brandon Keepers',
+                email: 'bkeepers@github.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'Brandon Keepers',
+              email: 'bkeepers@github.com',
+              committer: 'Bex Warner',
+              message: 'Expected "Brandon Keepers <bkeepers@github.com>", but got "Brandon Keepers < bkeepers@github.com >".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit has "Signed-off-by:" text but name is missing', async () => {
+            const commit = {
+              message: 'bad signoff\n\nsigned-off-by: <hiimbex@disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit has "Signed-off-by:" text but email is missing', async () => {
+            const commit = {
+              message: 'bad signoff\n\nsigned-off-by: hiimbex',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit has "Signed-off-by:" text but email is missing angle brackets', async () => {
+            const commit = {
+              message: 'bad signoff\n\nsigned-off-by: hiimbex hiimbex@disney.com',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit has "Signed-off-by:" text but name and email are missing', async () => {
+            const commit = {
+              message: 'bad signoff\n\nsigned-off-by: ',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit has "Signed-off-by:" text but name and email are swapped', async () => {
+            const commit = {
+              message: 'bad signoff\n\nsigned-off-by: hiimbex@disney.com <hiimbex>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "hiimbex <hiimbex@disney.com>", but got "hiimbex@disney.com <hiimbex>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit has "Signed-off-by:" text but email is invalid (missing @)', async () => {
+            const commit = {
+              message: 'bad email\n\nsigned-off-by: hiimbex <hiimbex(at)disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "hiimbex <hiimbex@disney.com>", but got "hiimbex <hiimbex(at)disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit has "Signed-off-by:" text but email is invalid (missing TLD)', async () => {
+            const commit = {
+              message: 'bad email\n\nsigned-off-by: hiimbex <hiimbex@bexo>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@bexo'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@bexo',
+              committer: 'Bex Warner',
+              message: 'hiimbex@bexo is not a valid email address.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single commit is signed-off with email containing plus aliasing, but author does not use plus aliasing', async () => {
+            const commit = {
+              message: 'signed off correctly\n\nsigned-off-by: hiimbex <hiimbex+alias@disney.com>\n\n',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'hiimbex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "hiimbex <hiimbex@disney.com>", but got "hiimbex <hiimbex+alias@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('Single unverified commit is from an org member, no sign-off', async () => {
+            const commit = {
+              message: 'yolo',
+              author: {
+                name: 'Lorant Pinter',
+                email: 'lorant.pinter@gmail.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              },
+              verification: {
+                verified: false
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA}], dontRequireSignoffFor('lptr'), prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'Lorant Pinter',
+              email: 'lorant.pinter@gmail.com',
+              committer: 'Bex Warner',
+              message: 'Commit by organization member is not verified.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+        })
+      })
+
+      describe('Two commits', () => {
+
+        describe('Success patterns', () => {
+
+          test('First commit is correctly signed-off; second commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('First commit is correctly signed-off by one of multiple sign-offs; second commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>\nSigned-off-by: Brian Warner <brian@bdwarner.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('First commit is correctly signed-off; second commit is correctly signed-off by one of multiple sign-offs', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>\nSigned-off-by: Brian Warner <brian@bdwarner.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('First commit is correctly signed-off by one of multiple sign-offs; second commit is correctly signed-off by one of multiple sign-offs', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>\nSigned-off-by: Brian Warner <brian@bdwarner.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>\nSigned-off-by: Brian Warner <brian@bdwarner.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+        })
+
+        describe('Failure patterns:', () => {
+
+          test('First commit does not contain a sign-off; second commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('First commit is correctly signed-off, second commit does not contain a sign-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+            }])
+          })
+
+          test('First commit is incorrectly signed-off, second commit does not contain a sign-off', async () => {
+            const commitA = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+              },{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+            }])
+          })
+        })
+      })
+
+      describe('Three commits', () => {
+
+        describe('Success patterns', () => {
+
+          test('First commit is correctly signed-off; second commit is correctly signed-off; third commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('First commit is correctly signed-off; second commit is correctly signed-off by one of multiple sign-offs; third commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>\nSigned-off-by: Brian Warner <brian@bdwarner.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+        })
+
+        describe('Failure patterns', () => {
+
+          test('First commit is incorrectly signed-off; second commit is correctly signed-off; third commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+          test('First commit is correctly signed-off; second commit is incorrectly signed-off; third commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+            }])
+          })
+
+          test('First commit is correctly signed-off; second commit is correctly signed-off; third commit is incorrectly signed-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '966587f0902920ed656950b0766e1073f8a532c0'
+            }])
+          })
+
+          test('First commit is incorrectly signed-off; second commit is incorrectly signed-off; third commit is correctly signed-off', async () => {
+            const commitA = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+              },{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+            }])
+          })
+
+          test('First commit is correctly signed-off; second commit is incorrectly signed-off; third commit is incorrectly signed-off', async () => {
+            const commitA = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+              },{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: '966587f0902920ed656950b0766e1073f8a532c0'
+            }])
+          })
+
+          test('First commit is incorrectly signed-off; second commit is correctly signed-off; third commit is incorrectly signed-off', async () => {
+            const commitA = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+              },{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: '966587f0902920ed656950b0766e1073f8a532c0'
+            }])
+          })
+
+          test('First commit is incorrectly signed-off; second commit is incorrectly signed-off; third commit is incorrectly signed-off', async () => {
+            const commitA = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+              },{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+              },{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+                sha: '966587f0902920ed656950b0766e1073f8a532c0'
+            }])
+          })
+        })
+      })
+    })
+
+    describe('Verify individual remediation with third-party remediations enabled', () => {
+
+/*
+* The tests in this section verify the behavior of third-party remediation.
+*/
+
+      describe('Success patterns', () => {
+
+        test('First commit does not contain a sign-off; second commit has individual remediation and sign-off', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual(success)
+        })
+
+        test('First commit has a sign-off, name incorrect; second commit has individual remediation and sign-off', async () => {
+          const commitA = {
+            message: 'Signed-off-by: hiimbex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual(success)
+        })
+
+        test('First commit has a sign-off, email incorrect; second commit has individual remediation and sign-off', async () => {
+          const commitA = {
+            message: 'Signed-off-by: bex <hiimbex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual(success)
+        })
+
+        test('First commit contains a sign-off; second commit has redundant individual remediation and sign-off', async () => {
+          const commitA = {
+            message: 'Signed-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual(success)
+        })
+
+        test('First commit contains a sign-off; second commit has individual remediation for a non-existent sha and sign-off', async () => {
+          const commitA = {
+            message: 'Signed-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 2222222222222222222222222222222222222222\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual(success)
+        })
+
+        test('First commit has no sign-off; second commit has individual remediation, no sign-off; third commit has individual remediation and is correctly signed-off', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitC = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual(success)
+        })
+
+        test('First commit has no sign-off; second commit has no sign-off; third commit has individual remediations for both and is correctly signed-off', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitC = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\nI, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual(success)
+        })
+      })
+
+      describe("Failure patterns", () => {
+
+        test('First commit has no sign-off; second commit has remediation text but no sign-off', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has remediation and sign-off from a different author name', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, hiimbex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <bex@disney.com>',
+            author: {
+              name: 'hiimbex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has remediation and sign-off from a different author email', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <hiimbex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'hiimbex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has remediation and sign-off from a different author name and email', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+            author: {
+              name: 'hiimbex',
+              email: 'hiimbex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has correct remediation but sign-off from a different author name', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <bex@disney.com>',
+            author: {
+              name: 'hiimbex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has correct remediation but sign-off from a different author email', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <hiimbex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'hiimbex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has correct remediation but sign-off from a different author name and email', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+            author: {
+              name: 'hiimbex',
+              email: 'hiimbex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has correct sign-off but remediation from a different author name', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, hiimbex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has correct sign-off but remediation from a different author email',async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has correct sign-off but remediation from a different author name and email', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+
+        test('First commit has no sign-off; second commit has correct sign-off but remediation for a different sha', async () => {
+          const commitA = {
+            message: 'No signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 2222222222222222222222222222222222222222\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            }
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+
+          expect(dcoObject).toEqual([{
+            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: 'bex',
+            email: 'bex@disney.com',
+            committer: 'Bex Warner',
+            message: 'The sign-off is missing.',
+            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+          }])
+        })
+      })
+    })
+
+    describe('Verify third-party remediations', () => {
+      describe('Success patterns', () => {
+        test(
+          'First commit has no sign-off; second commit has correct 3rd party remediation from same author, has sign-off',
+          async () => {
+            const commitA = {
+              message: 'No signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'On behalf of bex <bex@disney.com>, I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+        test(
+          'First commit has no sign-off; second commit has correct 3rd party remediation from different author, has sign-off',
+          async () => {
+            const commitA = {
+              message: 'No signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+        test(
+          'First commit has no sign-off; second commit has correct 3rd party remediation from committer, has sign-off',
+          async () => {
+            const commitA = {
+              message: 'No signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'On behalf of bex <bex@disney.com>, I, Bex Warner <bexmwarner@gmail.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+        test(
+          'First commit has no sign-off; second commit has correct 3rd party remediation from verified org member, has sign-off',
+          async () => {
+            const commitA = {
+              message: 'No signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              },
+              verification: {
+                verified: true
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'bex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}],  dontRequireSignoffFor('hiimbex'), prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('First commit has sign-off; second commit has redundant individual remediation, has sign-off; third commit has redundant third-party remediation, has sign-off', async () => {
+            const commitA = {
+              message: 'Signed-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('First commit has no sign-off; second commit has individual remediation, has sign-off; third commit has redundant third-party remediation, has sign-off', async () => {
+            const commitA = {
+              message: 'no signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('First commit has no sign-off; second commit has individual remediation, no sign-off; third commit has third-party remediation, has sign-off', async () => {
+            const commitA = {
+              message: 'no signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('First commit has no sign-off; second commit has third-party remediation, no sign-off; third commit has individual remediation of second commit, has sign-off', async () => {
+            const commitA = {
+              message: 'no signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+          test('First commit has no sign-off; second commit has third-party remediation, no sign-off; third commit has third-party remediation of second commit, has sign-off', async () => {
+            const commitA = {
+              message: 'no signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'On behalf of hiimbex <hiimbex@disney.com>, I, Bex Warner <bexmwarner@gmail.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+              author: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+
+        test(
+          'First commit has no sign-off; second commit has correct 3rd party remediation text for first commit, no sign-off; third commit from committer has correct 3rd party remediation text for second commit, has sign-off',
+          async () => {
+            const commitA = {
+              message: 'No signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'On behalf of hiimbex <hiimbex@disney.com>, I, Bex Warner <bexmwarner@gmail.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+              author: {
+                name: 'Not Bex',
+                email: 'notbex@gmail.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual(success)
+          })
+      })
+
+      describe('Failure patterns', () => {
+        test(
+          'First commit has no sign-off; second commit has correct 3rd party remediation; individual remediations disabled',
+          async () => {
+            const commitA = {
+              message: 'No signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'The sign-off is missing.',
+                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+        test(
+          'First commit has no sign-off; second commit has 3rd party remediation for wrong email, has sign-off',
+          async () => {
+            const commitA = {
+              message: 'No signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'On behalf of bex <hiimbex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'The sign-off is missing.',
+                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+        test(
+          'First commit has no sign-off; second commit has 3rd party remediation for wrong name, has sign-off',
+          async () => {
+            const commitA = {
+              message: 'No signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'On behalf of Bex Warner <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'The sign-off is missing.',
+                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+        test(
+          'First commit has no sign-off; second commit has 3rd party remediation for wrong sha, has sign-off',
+          async () => {
+            const commitA = {
+              message: 'No signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 2222222222222222222222222222222222222222\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'The sign-off is missing.',
+                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+        test(
+          'First commit has no sign-off; second commit has mangled 3rd party remediation text, has sign-off',
+          async () => {
+            const commitA = {
+              message: 'No signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'For bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'The sign-off is missing.',
+                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+        test(
+          'First commit has no sign-off; second commit has correct 3rd party remediation text but wrong remediator email, has sign-off',
+          async () => {
+            const commitA = {
+              message: 'No signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'The sign-off is missing.',
+                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+        test(
+          'First commit has no sign-off; second commit has correct 3rd party remediation text but wrong remediator name, has sign-off',
+          async () => {
+            const commitA = {
+              message: 'No signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'On behalf of bex <bex@disney.com>, I, bex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+                author: 'bex',
+                email: 'bex@disney.com',
+                committer: 'Bex Warner',
+                message: 'The sign-off is missing.',
+                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }])
+          })
+
+        test(
+          'First commit has no sign-off; second commit has correct 3rd party remediation text, no sign-off',
+          async () => {
+            const commitA = {
+              message: 'No signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+                url:  'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+                author: 'hiimbex',
+                email: 'hiimbex@disney.com',
+                committer: 'Bex Warner',
+                message: 'The sign-off is missing.',
+                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+            }])
+          })
+
+        test(
+          'First commit has no sign-off; second commit has correct 3rd party remediation text for first commit, no sign-off; third commit from committer has correct 3rd party remediation text for second commit, no sign-off',
+          async () => {
+            const commitA = {
+              message: 'No signoff',
+              author: {
+                name: 'bex',
+                email: 'bex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitB = {
+              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: {
+                name: 'hiimbex',
+                email: 'hiimbex@disney.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const commitC = {
+              message: 'On behalf of hiimbex <hiimbex@disney.com>, I, Bex Warner <bexmwarner@gmail.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e',
+              author: {
+                name: 'Not Bex',
+                email: 'notbex@gmail.com'
+              },
+              committer: {
+                name: 'Bex Warner',
+                email: 'bexmwarner@gmail.com'
+              }
+            }
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+
+            expect(dcoObject).toEqual([{
+                url:  'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+                author: 'Not Bex',
+                email: 'notbex@gmail.com',
+                committer: 'Bex Warner',
+                message: 'The sign-off is missing.',
+                sha: '966587f0902920ed656950b0766e1073f8a532c0'
+            }])
+          })
+
+      })
+    })
+  })
+})

--- a/test/dco.test.js
+++ b/test/dco.test.js
@@ -28,9 +28,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
 */
 
   describe('Single commit', () => {
-
     describe('Success patterns', () => {
-
       test('Single commit is correctly signed-off', async () => {
         const commit = {
           message: 'Hello world\n\nSigned-off-by: Brandon Keepers <bkeepers@github.com>',
@@ -43,7 +41,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -62,7 +60,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -81,7 +79,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -98,7 +96,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -115,7 +113,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -132,14 +130,14 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
 
       test('Single commit is correctly signed-off with trailing whitespace', async () => {
         const commit = {
-          message: 'signed off correctly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>			',
+          message: 'signed off correctly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>  ',
           author: {
             name: 'hiimbex',
             email: 'hiimbex@disney.com'
@@ -149,7 +147,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -166,7 +164,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -183,7 +181,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -200,7 +198,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -218,7 +216,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
           }
         }
         const author = null
-        const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -236,7 +234,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
           }
         }
         const author = null
-        const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -253,7 +251,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [1, 2], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [1, 2], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -274,7 +272,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
           login: 'bexobot [bot]',
           type: 'Bot'
         }
-        const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -294,14 +292,13 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             verified: true
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA}], dontRequireSignoffFor('lptr'), prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA }], dontRequireSignoffFor('lptr'), prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
     })
 
     describe('Failure patterns:', () => {
-
       test('Single commit does not contain a sign-off', async () => {
         const commit = {
           message: 'yolo',
@@ -314,7 +311,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -339,7 +336,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
           }
         }
         const author = null
-        const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -365,15 +362,15 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'committer@email.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
-          'author': 'Author Name',
-          'email': 'author@email.com',
-          'committer': 'Committer Name',
-          'message': 'Can not find "Author Name <author@email.com>", in ["Tester1 <tester1@github.com>", "Tester2 <tester2@github.com>"].',
-          'sha': '18aebfa67dde85da0f5099ad70ef647685a05205',
-          'url': 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205'
+          author: 'Author Name',
+          email: 'author@email.com',
+          committer: 'Committer Name',
+          message: 'Can not find "Author Name <author@email.com>", in ["Tester1 <tester1@github.com>", "Tester2 <tester2@github.com>"].',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205',
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205'
         }])
       })
 
@@ -389,7 +386,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -413,7 +410,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -437,7 +434,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -461,7 +458,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -485,7 +482,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -509,7 +506,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -533,7 +530,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -557,7 +554,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -581,7 +578,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -605,7 +602,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -629,7 +626,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -653,7 +650,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -677,7 +674,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -704,7 +701,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             verified: false
           }
         }
-        const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA}], dontRequireSignoffFor('lptr'), prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA }], dontRequireSignoffFor('lptr'), prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -719,9 +716,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
   })
 
   describe('Two commits', () => {
-
     describe('Success patterns', () => {
-
       test('First commit is correctly signed-off; second commit is correctly signed-off', async () => {
         const commitA = {
           message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
@@ -745,7 +740,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -773,7 +768,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -801,7 +796,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -829,14 +824,13 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
     })
 
     describe('Failure patterns', () => {
-
       test('First commit does not contain a sign-off; second commit is correctly signed-off', async () => {
         const commitA = {
           message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
@@ -860,7 +854,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -895,7 +889,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
@@ -930,31 +924,29 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
-            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-            author: 'bex',
-            email: 'bex@disney.com',
-            committer: 'Bex Warner',
-            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-          },{
-            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
-            author: 'bex',
-            email: 'bex@disney.com',
-            committer: 'Bex Warner',
-            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-            sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }, {
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
         }])
       })
     })
   })
 
   describe('Three commits', () => {
-
     describe('Success patterns', () => {
-
       test('First commit is correctly signed-off; second commit is correctly signed-off; third commit is correctly signed-off', async () => {
         const commitA = {
           message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
@@ -989,7 +981,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
@@ -1028,14 +1020,13 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual(success)
       })
     })
 
     describe('Failure patterns', () => {
-
       test('First commit is incorrectly signed-off; second commit is correctly signed-off; third commit is correctly signed-off', async () => {
         const commitA = {
           message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
@@ -1070,7 +1061,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -1116,7 +1107,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
@@ -1162,7 +1153,7 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
@@ -1208,22 +1199,22 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
-            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-            author: 'bex',
-            email: 'bex@disney.com',
-            committer: 'Bex Warner',
-            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-          },{
-            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
-            author: 'bex',
-            email: 'bex@disney.com',
-            committer: 'Bex Warner',
-            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-            sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }, {
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
         }])
       })
 
@@ -1261,22 +1252,22 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
-            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
-            author: 'bex',
-            email: 'bex@disney.com',
-            committer: 'Bex Warner',
-            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-            sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
-          },{
-            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
-            author: 'bex',
-            email: 'bex@disney.com',
-            committer: 'Bex Warner',
-            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-            sha: '966587f0902920ed656950b0766e1073f8a532c0'
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+        }, {
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: '966587f0902920ed656950b0766e1073f8a532c0'
         }])
       })
 
@@ -1314,22 +1305,22 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
-            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-            author: 'bex',
-            email: 'bex@disney.com',
-            committer: 'Bex Warner',
-            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-          },{
-            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
-            author: 'bex',
-            email: 'bex@disney.com',
-            committer: 'Bex Warner',
-            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-            sha: '966587f0902920ed656950b0766e1073f8a532c0'
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }, {
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: '966587f0902920ed656950b0766e1073f8a532c0'
         }])
       })
 
@@ -1367,29 +1358,29 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
-            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-            author: 'bex',
-            email: 'bex@disney.com',
-            committer: 'Bex Warner',
-            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-            sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-          },{
-            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
-            author: 'bex',
-            email: 'bex@disney.com',
-            committer: 'Bex Warner',
-            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-            sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
-          },{
-            url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
-            author: 'bex',
-            email: 'bex@disney.com',
-            committer: 'Bex Warner',
-            message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-            sha: '966587f0902920ed656950b0766e1073f8a532c0'
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+        }, {
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+        }, {
+          url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+          author: 'bex',
+          email: 'bex@disney.com',
+          committer: 'Bex Warner',
+          message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+          sha: '966587f0902920ed656950b0766e1073f8a532c0'
         }])
       })
     })
@@ -1397,7 +1388,6 @@ describe('EXPLICIT DCO SIGN-OFFS', () => {
 })
 
 describe('INDIVIDUAL REMEDIATION COMMITS', () => {
-
 /*
 * The tests in this section verify Probot DCO's behavior when configured to allow individual
 * remediation commits. In order to be valid, an individual remediation commit must contain
@@ -1409,9 +1399,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
 */
 
   describe('Disabled (default)', () => {
-
     describe('Failure patterns', () => {
-
       test('First commit does not contain a sign-off; second commit contains sign-off and correct individual remediation', async () => {
         const commitA = {
           message: 'No signoff',
@@ -1435,7 +1423,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -1450,19 +1438,15 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
   })
 
   describe('Enabled via config option', () => {
-
     describe('Verify default functionality is unchanged', () => {
-
-/*
+      /*
 * The tests in this section mirror the explicit sign-off tests exactly, except individual
 * remediation is enabled. This first sequence of tests ensures that no functionality
 * changes when individual remediation commits are enabled.
 */
 
       describe('Single commit', () => {
-
         describe('Success patterns', () => {
-
           test('Single commit is correctly signed-off', async () => {
             const commit = {
               message: 'Hello world\n\nSigned-off-by: Brandon Keepers <bkeepers@github.com>',
@@ -1475,7 +1459,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -1494,7 +1478,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -1513,7 +1497,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -1530,7 +1514,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -1547,7 +1531,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -1564,14 +1548,14 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
 
           test('Single commit is correctly signed-off with trailing whitespace', async () => {
             const commit = {
-              message: 'signed off correctly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>			',
+              message: 'signed off correctly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>  ',
               author: {
                 name: 'hiimbex',
                 email: 'hiimbex@disney.com'
@@ -1581,7 +1565,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -1598,7 +1582,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -1615,7 +1599,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -1632,7 +1616,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -1650,7 +1634,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               }
             }
             const author = null
-            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -1668,7 +1652,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               }
             }
             const author = null
-            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -1685,7 +1669,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [1, 2], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [1, 2], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -1706,7 +1690,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               login: 'bexobot [bot]',
               type: 'Bot'
             }
-            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -1726,14 +1710,13 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 verified: true
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA}], dontRequireSignoffFor('lptr'), prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA }], dontRequireSignoffFor('lptr'), prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
         })
 
         describe('Failure patterns', () => {
-
           test('Single commit does not contain a sign-off', async () => {
             const commit = {
               message: 'yolo',
@@ -1746,7 +1729,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -1771,7 +1754,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               }
             }
             const author = null
-            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -1797,15 +1780,15 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'committer@email.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
-              'author': 'Author Name',
-              'email': 'author@email.com',
-              'committer': 'Committer Name',
-              'message': 'Can not find "Author Name <author@email.com>", in ["Tester1 <tester1@github.com>", "Tester2 <tester2@github.com>"].',
-              'sha': '18aebfa67dde85da0f5099ad70ef647685a05205',
-              'url': 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205'
+              author: 'Author Name',
+              email: 'author@email.com',
+              committer: 'Committer Name',
+              message: 'Can not find "Author Name <author@email.com>", in ["Tester1 <tester1@github.com>", "Tester2 <tester2@github.com>"].',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205',
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205'
             }])
           })
 
@@ -1821,7 +1804,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -1845,7 +1828,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -1869,7 +1852,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -1893,7 +1876,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -1917,7 +1900,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -1941,7 +1924,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -1965,7 +1948,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -1989,7 +1972,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -2013,7 +1996,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -2037,7 +2020,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -2061,7 +2044,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -2085,7 +2068,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -2109,7 +2092,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -2136,7 +2119,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 verified: false
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA}], dontRequireSignoffFor('lptr'), prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA }], dontRequireSignoffFor('lptr'), prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -2151,9 +2134,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
       })
 
       describe('Two commits', () => {
-
         describe('Success patterns', () => {
-
           test('First commit is correctly signed-off; second commit is correctly signed-off', async () => {
             const commitA = {
               message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
@@ -2177,7 +2158,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -2205,7 +2186,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -2233,7 +2214,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -2261,14 +2242,13 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
         })
 
         describe('Failure patterns:', () => {
-
           test('First commit does not contain a sign-off; second commit is correctly signed-off', async () => {
             const commitA = {
               message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
@@ -2292,7 +2272,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -2327,7 +2307,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
@@ -2362,31 +2342,29 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-              },{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }, {
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
             }])
           })
         })
       })
 
       describe('Three commits', () => {
-
         describe('Success patterns', () => {
-
           test('First commit is correctly signed-off; second commit is correctly signed-off; third commit is correctly signed-off', async () => {
             const commitA = {
               message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
@@ -2421,7 +2399,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
@@ -2460,14 +2438,13 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual(success)
           })
         })
 
         describe('Failure patterns', () => {
-
           test('First commit is incorrectly signed-off; second commit is correctly signed-off; third commit is correctly signed-off', async () => {
             const commitA = {
               message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
@@ -2502,7 +2479,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -2548,7 +2525,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
@@ -2594,7 +2571,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
@@ -2640,22 +2617,22 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-              },{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }, {
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
             }])
           })
 
@@ -2693,22 +2670,22 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
-              },{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: '966587f0902920ed656950b0766e1073f8a532c0'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+            }, {
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '966587f0902920ed656950b0766e1073f8a532c0'
             }])
           })
 
@@ -2746,22 +2723,22 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-              },{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: '966587f0902920ed656950b0766e1073f8a532c0'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }, {
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '966587f0902920ed656950b0766e1073f8a532c0'
             }])
           })
 
@@ -2799,29 +2776,29 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-              },{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
-              },{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: '966587f0902920ed656950b0766e1073f8a532c0'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }, {
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+            }, {
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '966587f0902920ed656950b0766e1073f8a532c0'
             }])
           })
         })
@@ -2829,13 +2806,11 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
     })
 
     describe('Verify individual remediations', () => {
-
-/*
+      /*
 * The tests in this section verify the behavior of individual remediation.
 */
 
       describe('Success patterns', () => {
-
         test('First commit does not contain a sign-off; second commit has individual remediation and sign-off', async () => {
           const commitA = {
             message: 'No signoff',
@@ -2859,7 +2834,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual(success)
         })
@@ -2887,7 +2862,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual(success)
         })
@@ -2915,7 +2890,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual(success)
         })
@@ -2943,7 +2918,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual(success)
         })
@@ -2971,7 +2946,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual(success)
         })
@@ -3010,7 +2985,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual(success)
         })
@@ -3049,14 +3024,13 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual(success)
         })
       })
 
-      describe("Failure patterns", () => {
-
+      describe('Failure patterns', () => {
         test('First commit has no sign-off; second commit has remediation text but no sign-off', async () => {
           const commitA = {
             message: 'No signoff',
@@ -3080,7 +3054,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
@@ -3115,7 +3089,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3150,7 +3124,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3185,7 +3159,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3220,7 +3194,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3255,7 +3229,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3290,7 +3264,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3325,7 +3299,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3337,7 +3311,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
           }])
         })
 
-        test('First commit has no sign-off; second commit has correct sign-off but remediation from a different author email',async () => {
+        test('First commit has no sign-off; second commit has correct sign-off but remediation from a different author email', async () => {
           const commitA = {
             message: 'No signoff',
             author: {
@@ -3360,7 +3334,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3395,7 +3369,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3430,7 +3404,7 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3447,7 +3421,6 @@ describe('INDIVIDUAL REMEDIATION COMMITS', () => {
 })
 
 describe('THIRD PARTY REMEDIATION COMMITS', () => {
-
 /*
 * The tests in this section verify Probot DCO's behavior when configured to allow
 * third-party remediation commits. In order to be valid, a third-party remediation commit
@@ -3457,9 +3430,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
 */
 
   describe('Disabled (default)', () => {
-
     describe('Failure patterns', () => {
-
       test('First commit does not contain a sign-off; second commit contains sign-off and correct third-party remediation', async () => {
         const commitA = {
           message: 'No signoff',
@@ -3483,7 +3454,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3518,7 +3489,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
             email: 'bexmwarner@gmail.com'
           }
         }
-        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+        const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
         expect(dcoObject).toEqual([{
           url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3529,24 +3500,19 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
           sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
         }])
       })
-
     })
   })
 
   describe('Enabled via config option', () => {
-
     describe('Verify default functionality is unchanged', () => {
-
-/*
+      /*
 * The tests in this section mirror the explicit sign-off tests exactly, except individual
 * remediation is enabled. This first sequence of tests ensures that no functionality
 * changes when individual remediation commits are enabled.
 */
 
       describe('Single commit', () => {
-
         describe('Success patterns', () => {
-
           test('Single commit is correctly signed-off', async () => {
             const commit = {
               message: 'Hello world\n\nSigned-off-by: Brandon Keepers <bkeepers@github.com>',
@@ -3559,7 +3525,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -3578,7 +3544,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -3597,7 +3563,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -3614,7 +3580,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -3631,7 +3597,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -3648,14 +3614,14 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
 
           test('Single commit is correctly signed-off with trailing whitespace', async () => {
             const commit = {
-              message: 'signed off correctly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>			',
+              message: 'signed off correctly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>  ',
               author: {
                 name: 'hiimbex',
                 email: 'hiimbex@disney.com'
@@ -3665,7 +3631,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -3682,7 +3648,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -3699,7 +3665,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -3716,7 +3682,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -3734,7 +3700,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               }
             }
             const author = null
-            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -3752,7 +3718,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               }
             }
             const author = null
-            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -3769,7 +3735,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [1, 2], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [1, 2], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -3790,7 +3756,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               login: 'bexobot [bot]',
               type: 'Bot'
             }
-            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -3810,14 +3776,13 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 verified: true
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA}], dontRequireSignoffFor('lptr'), prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA }], dontRequireSignoffFor('lptr'), prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
         })
 
         describe('Failure patterns', () => {
-
           test('Single commit does not contain a sign-off', async () => {
             const commit = {
               message: 'yolo',
@@ -3830,7 +3795,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3855,7 +3820,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               }
             }
             const author = null
-            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3881,15 +3846,15 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'committer@email.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
-              'author': 'Author Name',
-              'email': 'author@email.com',
-              'committer': 'Committer Name',
-              'message': 'Can not find "Author Name <author@email.com>", in ["Tester1 <tester1@github.com>", "Tester2 <tester2@github.com>"].',
-              'sha': '18aebfa67dde85da0f5099ad70ef647685a05205',
-              'url': 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205'
+              author: 'Author Name',
+              email: 'author@email.com',
+              committer: 'Committer Name',
+              message: 'Can not find "Author Name <author@email.com>", in ["Tester1 <tester1@github.com>", "Tester2 <tester2@github.com>"].',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205',
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205'
             }])
           })
 
@@ -3905,7 +3870,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3929,7 +3894,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3953,7 +3918,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -3977,7 +3942,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -4001,7 +3966,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'bkeepers' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -4025,7 +3990,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -4049,7 +4014,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -4073,7 +4038,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -4097,7 +4062,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -4121,7 +4086,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -4145,7 +4110,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -4169,7 +4134,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -4193,7 +4158,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'hiimbex' }, parents: [], sha: shaA }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -4220,7 +4185,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 verified: false
               }
             }
-            const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA}], dontRequireSignoffFor('lptr'), prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit, author: { login: 'lptr' }, parents: [], sha: shaA }], dontRequireSignoffFor('lptr'), prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -4235,9 +4200,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
       })
 
       describe('Two commits', () => {
-
         describe('Success patterns', () => {
-
           test('First commit is correctly signed-off; second commit is correctly signed-off', async () => {
             const commitA = {
               message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
@@ -4261,7 +4224,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -4289,7 +4252,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -4317,7 +4280,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -4345,14 +4308,13 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
         })
 
         describe('Failure patterns:', () => {
-
           test('First commit does not contain a sign-off; second commit is correctly signed-off', async () => {
             const commitA = {
               message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
@@ -4376,7 +4338,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -4411,7 +4373,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [] }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
@@ -4446,31 +4408,29 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-              },{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }, {
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
             }])
           })
         })
       })
 
       describe('Three commits', () => {
-
         describe('Success patterns', () => {
-
           test('First commit is correctly signed-off; second commit is correctly signed-off; third commit is correctly signed-off', async () => {
             const commitA = {
               message: 'signed off correctly\n\nSigned-off-by: bex <bex@disney.com>',
@@ -4505,7 +4465,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -4544,14 +4504,13 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
         })
 
         describe('Failure patterns', () => {
-
           test('First commit is incorrectly signed-off; second commit is correctly signed-off; third commit is correctly signed-off', async () => {
             const commitA = {
               message: 'signed off incorrectly\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
@@ -4586,7 +4545,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -4632,7 +4591,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
@@ -4678,7 +4637,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
               url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
@@ -4724,22 +4683,22 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-              },{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }, {
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
             }])
           })
 
@@ -4777,22 +4736,22 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
-              },{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: '966587f0902920ed656950b0766e1073f8a532c0'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+            }, {
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '966587f0902920ed656950b0766e1073f8a532c0'
             }])
           })
 
@@ -4830,22 +4789,22 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-              },{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: '966587f0902920ed656950b0766e1073f8a532c0'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }, {
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '966587f0902920ed656950b0766e1073f8a532c0'
             }])
           })
 
@@ -4883,29 +4842,29 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
-              },{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
-              },{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
-                sha: '966587f0902920ed656950b0766e1073f8a532c0'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+            }, {
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+            }, {
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'Expected "bex <bex@disney.com>", but got "hiimbex <hiimbex@disney.com>".',
+              sha: '966587f0902920ed656950b0766e1073f8a532c0'
             }])
           })
         })
@@ -4913,13 +4872,11 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
     })
 
     describe('Verify individual remediation with third-party remediations enabled', () => {
-
-/*
+      /*
 * The tests in this section verify the behavior of third-party remediation.
 */
 
       describe('Success patterns', () => {
-
         test('First commit does not contain a sign-off; second commit has individual remediation and sign-off', async () => {
           const commitA = {
             message: 'No signoff',
@@ -4943,7 +4900,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual(success)
         })
@@ -4971,7 +4928,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual(success)
         })
@@ -4999,7 +4956,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual(success)
         })
@@ -5027,7 +4984,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual(success)
         })
@@ -5055,7 +5012,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual(success)
         })
@@ -5094,7 +5051,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual(success)
         })
@@ -5133,14 +5090,13 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual(success)
         })
       })
 
-      describe("Failure patterns", () => {
-
+      describe('Failure patterns', () => {
         test('First commit has no sign-off; second commit has remediation text but no sign-off', async () => {
           const commitA = {
             message: 'No signoff',
@@ -5164,7 +5120,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
@@ -5199,7 +5155,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -5234,7 +5190,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -5269,7 +5225,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -5304,7 +5260,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -5339,7 +5295,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -5374,7 +5330,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -5409,7 +5365,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -5421,7 +5377,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
           }])
         })
 
-        test('First commit has no sign-off; second commit has correct sign-off but remediation from a different author email',async () => {
+        test('First commit has no sign-off; second commit has correct sign-off but remediation from a different author email', async () => {
           const commitA = {
             message: 'No signoff',
             author: {
@@ -5444,7 +5400,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -5479,7 +5435,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -5514,7 +5470,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
               email: 'bexmwarner@gmail.com'
             }
           }
-          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: false})
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: false })
 
           expect(dcoObject).toEqual([{
             url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
@@ -5555,7 +5511,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -5585,7 +5541,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -5615,7 +5571,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -5648,205 +5604,205 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 verified: true
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'bex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}],  dontRequireSignoffFor('hiimbex'), prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'bex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], dontRequireSignoffFor('hiimbex'), prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
 
-          test('First commit has sign-off; second commit has redundant individual remediation, has sign-off; third commit has redundant third-party remediation, has sign-off', async () => {
-            const commitA = {
-              message: 'Signed-off-by: bex <bex@disney.com>',
-              author: {
-                name: 'bex',
-                email: 'bex@disney.com'
-              },
-              committer: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              }
+        test('First commit has sign-off; second commit has redundant individual remediation, has sign-off; third commit has redundant third-party remediation, has sign-off', async () => {
+          const commitA = {
+            message: 'Signed-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
             }
-            const commitB = {
-              message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
-              author: {
-                name: 'bex',
-                email: 'bex@disney.com'
-              },
-              committer: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
             }
-            const commitC = {
-              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
-              author: {
-                name: 'hiimbex',
-                email: 'hiimbex@disney.com'
-              },
-              committer: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              }
+          }
+          const commitC = {
+            message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+            author: {
+              name: 'hiimbex',
+              email: 'hiimbex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
-            expect(dcoObject).toEqual(success)
-          })
+          expect(dcoObject).toEqual(success)
+        })
 
-          test('First commit has no sign-off; second commit has individual remediation, has sign-off; third commit has redundant third-party remediation, has sign-off', async () => {
-            const commitA = {
-              message: 'no signoff',
-              author: {
-                name: 'bex',
-                email: 'bex@disney.com'
-              },
-              committer: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              }
+        test('First commit has no sign-off; second commit has individual remediation, has sign-off; third commit has redundant third-party remediation, has sign-off', async () => {
+          const commitA = {
+            message: 'no signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
             }
-            const commitB = {
-              message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
-              author: {
-                name: 'bex',
-                email: 'bex@disney.com'
-              },
-              committer: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205\n\nSigned-off-by: bex <bex@disney.com>',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
             }
-            const commitC = {
-              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
-              author: {
-                name: 'hiimbex',
-                email: 'hiimbex@disney.com'
-              },
-              committer: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              }
+          }
+          const commitC = {
+            message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+            author: {
+              name: 'hiimbex',
+              email: 'hiimbex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
-            expect(dcoObject).toEqual(success)
-          })
+          expect(dcoObject).toEqual(success)
+        })
 
-          test('First commit has no sign-off; second commit has individual remediation, no sign-off; third commit has third-party remediation, has sign-off', async () => {
-            const commitA = {
-              message: 'no signoff',
-              author: {
-                name: 'bex',
-                email: 'bex@disney.com'
-              },
-              committer: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              }
+        test('First commit has no sign-off; second commit has individual remediation, no sign-off; third commit has third-party remediation, has sign-off', async () => {
+          const commitA = {
+            message: 'no signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
             }
-            const commitB = {
-              message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
-              author: {
-                name: 'bex',
-                email: 'bex@disney.com'
-              },
-              committer: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              }
+          }
+          const commitB = {
+            message: 'I, bex <bex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
             }
-            const commitC = {
-              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
-              author: {
-                name: 'hiimbex',
-                email: 'hiimbex@disney.com'
-              },
-              committer: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              }
+          }
+          const commitC = {
+            message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+            author: {
+              name: 'hiimbex',
+              email: 'hiimbex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
-            expect(dcoObject).toEqual(success)
-          })
+          expect(dcoObject).toEqual(success)
+        })
 
-          test('First commit has no sign-off; second commit has third-party remediation, no sign-off; third commit has individual remediation of second commit, has sign-off', async () => {
-            const commitA = {
-              message: 'no signoff',
-              author: {
-                name: 'bex',
-                email: 'bex@disney.com'
-              },
-              committer: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              }
+        test('First commit has no sign-off; second commit has third-party remediation, no sign-off; third commit has individual remediation of second commit, has sign-off', async () => {
+          const commitA = {
+            message: 'no signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
             }
-            const commitB = {
-              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
-              author: {
-                name: 'hiimbex',
-                email: 'hiimbex@disney.com'
-              },
-              committer: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              }
+          }
+          const commitB = {
+            message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: {
+              name: 'hiimbex',
+              email: 'hiimbex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
             }
-            const commitC = {
-              message: 'I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
-              author: {
-                name: 'hiimbex',
-                email: 'hiimbex@disney.com'
-              },
-              committer: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              }
+          }
+          const commitC = {
+            message: 'I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: hiimbex <hiimbex@disney.com>',
+            author: {
+              name: 'hiimbex',
+              email: 'hiimbex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
-            expect(dcoObject).toEqual(success)
-          })
+          expect(dcoObject).toEqual(success)
+        })
 
-          test('First commit has no sign-off; second commit has third-party remediation, no sign-off; third commit has third-party remediation of second commit, has sign-off', async () => {
-            const commitA = {
-              message: 'no signoff',
-              author: {
-                name: 'bex',
-                email: 'bex@disney.com'
-              },
-              committer: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              }
+        test('First commit has no sign-off; second commit has third-party remediation, no sign-off; third commit has third-party remediation of second commit, has sign-off', async () => {
+          const commitA = {
+            message: 'no signoff',
+            author: {
+              name: 'bex',
+              email: 'bex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
             }
-            const commitB = {
-              message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
-              author: {
-                name: 'hiimbex',
-                email: 'hiimbex@disney.com'
-              },
-              committer: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              }
+          }
+          const commitB = {
+            message: 'On behalf of bex <bex@disney.com>, I, hiimbex <hiimbex@disney.com>, hereby add my Signed-off-by to this commit: 18aebfa67dde85da0f5099ad70ef647685a05205',
+            author: {
+              name: 'hiimbex',
+              email: 'hiimbex@disney.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
             }
-            const commitC = {
-              message: 'On behalf of hiimbex <hiimbex@disney.com>, I, Bex Warner <bexmwarner@gmail.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
-              author: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              },
-              committer: {
-                name: 'Bex Warner',
-                email: 'bexmwarner@gmail.com'
-              }
+          }
+          const commitC = {
+            message: 'On behalf of hiimbex <hiimbex@disney.com>, I, Bex Warner <bexmwarner@gmail.com>, hereby add my Signed-off-by to this commit: d5f3e2be498459554b6465224b7b6f7c0682295e\n\nSigned-off-by: Bex Warner <bexmwarner@gmail.com>',
+            author: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
+            },
+            committer: {
+              name: 'Bex Warner',
+              email: 'bexmwarner@gmail.com'
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+          }
+          const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
-            expect(dcoObject).toEqual(success)
-          })
+          expect(dcoObject).toEqual(success)
+        })
 
         test(
           'First commit has no sign-off; second commit has correct 3rd party remediation text for first commit, no sign-off; third commit from committer has correct 3rd party remediation text for second commit, has sign-off',
@@ -5884,7 +5840,7 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual(success)
           })
@@ -5916,15 +5872,15 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: false, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: false, thirdParty: true })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'The sign-off is missing.',
-                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
             }])
           })
 
@@ -5953,15 +5909,15 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'The sign-off is missing.',
-                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
             }])
           })
 
@@ -5990,15 +5946,15 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'The sign-off is missing.',
-                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
             }])
           })
 
@@ -6027,15 +5983,15 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'The sign-off is missing.',
-                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
             }])
           })
 
@@ -6064,15 +6020,15 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'The sign-off is missing.',
-                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
             }])
           })
 
@@ -6101,15 +6057,15 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'The sign-off is missing.',
-                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
             }])
           })
 
@@ -6138,15 +6094,15 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
-                url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
-                author: 'bex',
-                email: 'bex@disney.com',
-                committer: 'Bex Warner',
-                message: 'The sign-off is missing.',
-                sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/18aebfa67dde85da0f5099ad70ef647685a05205',
+              author: 'bex',
+              email: 'bex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '18aebfa67dde85da0f5099ad70ef647685a05205'
             }])
           })
 
@@ -6175,15 +6131,15 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
-                url:  'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
-                author: 'hiimbex',
-                email: 'hiimbex@disney.com',
-                committer: 'Bex Warner',
-                message: 'The sign-off is missing.',
-                sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/d5f3e2be498459554b6465224b7b6f7c0682295e',
+              author: 'hiimbex',
+              email: 'hiimbex@disney.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: 'd5f3e2be498459554b6465224b7b6f7c0682295e'
             }])
           })
 
@@ -6223,18 +6179,17 @@ describe('THIRD PARTY REMEDIATION COMMITS', () => {
                 email: 'bexmwarner@gmail.com'
               }
             }
-            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA}, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB}, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC}], alwaysRequireSignoff, prInfo, {individual: true, thirdParty: true})
+            const dcoObject = await getDCOStatus([{ commit: commitA, author: { login: 'hiimbex' }, parents: [], sha: shaA }, { commit: commitB, author: { login: 'hiimbex' }, parents: [], sha: shaB }, { commit: commitC, author: { login: 'hiimbex' }, parents: [], sha: shaC }], alwaysRequireSignoff, prInfo, { individual: true, thirdParty: true })
 
             expect(dcoObject).toEqual([{
-                url:  'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
-                author: 'Not Bex',
-                email: 'notbex@gmail.com',
-                committer: 'Bex Warner',
-                message: 'The sign-off is missing.',
-                sha: '966587f0902920ed656950b0766e1073f8a532c0'
+              url: 'https://github.com/hiimbex/testing-things/pull/1/commits/966587f0902920ed656950b0766e1073f8a532c0',
+              author: 'Not Bex',
+              email: 'notbex@gmail.com',
+              committer: 'Bex Warner',
+              message: 'The sign-off is missing.',
+              sha: '966587f0902920ed656950b0766e1073f8a532c0'
             }])
           })
-
       })
     })
   })


### PR DESCRIPTION
This PR adds support for remediation commits and expands test coverage. In brief, a remediation commit is an additional way for projects to recognize valid, retroactive signoffs on commits which otherwise fail the Probot DCO checks. 

Remediations come in two flavors. Individual remediation commits allow an author to fix one or more failing commits by pushing an additional, properly signed-off commit with specific text indicating they apply their signoff retroactively. Third-party remediations allow someone other than the author to do this.

**About this PR**

First and foremost the default Probot DCO behavior is unchanged, although the default remediation text and recommendations are modified (for reasons explained in the commit message). Unless a project explicitly enables remediation commits via their repo's `.github/dco.yml` file, it will continue to strictly enforce the DCO and only permit commits that explicitly include a proper Signed-off-by line.

The first commit ([333a52f](https://github.com/probot/dco/commit/333a52f472923773519e3d8db00da552e1458d67)) expands and normalizes the default test cases. Running `./node_modules/jest/bin/jest.js --verbose` now returns a structured view of what we're testing, organized into success and failure scenarios. This helps ensure the default behavior remains constant through the subsequent changes.

The rest of the commits incrementally add support for remediation commits. [5aecad9](https://github.com/probot/dco/commit/5aecad9289eb135a39748306a85de032c92bc5db) modifies and consolidates the function that explains how to fix a failing PR, because it will be important later on. I also found a corner case in testing that makes me think it's better to just recommend all default fixes be rebases instead of amends. Basically if you push multiple commits and only one fails, and it's not the most recent commit, `git commit --amend` is going to fix the most recent commit and isn't going to fix the issue. Since both approaches required a force-push anyhow, it seemed less error prone to just recommend a rebase.

Next, [1a43157](https://github.com/probot/dco/commit/1a4315745dceeba8a15b3ec3554b14efb6d1e42e) adds full support for remediation commits. When a commit fails, the user gets specific copy-and-paste code blocks they can use to fix the problem. In addition the test cases are increased by 4x, because in addition to testing new functionality, they also repeat all of the previous tests to ensure enabling the config options does not mess with default results.

Finally [0696f05](https://github.com/probot/dco/commit/0696f05c1bef5690d81fa7ecab08116743996df2) updates the README.

**Why add this feature**

At the Linux Foundation we've heard feedback from some of our communities that DCO failures are trivial for some developers to remediate, but a barrier for others. In particular, some projects have expressed concern that one-time contributors are opening PRs through the GitHub web UI, are getting blocked because they don't know to add a signoff, and are simply abandoning their contributions rather than set up a local git environment, amend their patches, and push fixes. Currently the GitHub UI does not permit authors to amend commit messages, so this was conceived as a lighter weight workaround.

In addition, this enables targeted remediations. For example, if a branch contains multiple authors, a rebase will add an author's signoff to all commits, even ones they didn't author. This may not be desirable behavior. Both individual and third-party remediations allow an author to retroactively sign off on only the commits they want to fix. This could also be used when doing a bulk remediation on a project which adopted the DCO after being open sourced.

Finally, the goal was to establish standard text that could be replicated and understood by other tools. I specifically avoided an approach that relies upon GitHub tooling (such as signing off in the comment stream or on the PR itself) because this approach embeds the remediation directly in the git log, making it both portable and permanent.

**Due diligence**

I recognize this is a significant addition in functionality. Over the past year I've reviewed the concept with a number of open source legal folks and some of the large projects hosted at the Linux Foundation. The feedback has been generally positive, particularly given that it can be enabled on a project-by-project basis.

**Next steps**

These commits attempt to preserve the existing code style to generate a minimal diff, and make it easier to see what has changed. If merged, it would make sense to follow up with a linted version.

Thanks!

-----
[View rendered README.md](https://github.com/brianwarner/dco/blob/add-remediation-commits/README.md)