### PR TITLE
Add merge_group trigger to enable DCO in merge queue

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -46,6 +46,8 @@ default_events:
 # - team
 # - team_add
 # - watch
+  # Make DCO run in the merge queue
+  - merge_group
 
 # The set of permissions needed by the GitHub App. The format of the object uses
 # the permission name for the key (for example, issues) and the access type for


### PR DESCRIPTION
**Description**
Not sure whether this is the right fix -- add merge_group in the app.yml to enable DCO to run in merge queue.

**Motivation**
[Pull Request Merge Queue Public Beta](https://github.blog/changelog/2023-02-08-pull-request-merge-queue-public-beta/) is out, but DCO app cannot run in the merge queue. See related issue: https://github.com/dcoapp/app/issues/199. This PR is trying to enable DCO in the new merge queue. There are some related discussion about DCO [here](https://github.com/orgs/community/discussions/46757).
