### PR TITLE
fix(regex): Allow typos with multiple spaces in signed-off-by line

### DIFF
--- a/lib/dco.js
+++ b/lib/dco.js
@@ -119,7 +119,7 @@ function getSignoffs(
   allCommits,
   allowRemediationCommits
 ) {
-  const regex = /^Signed-off-by: (.*) <(.*)>\s*$/gim;
+  const regex = /^Signed-off-by:\s+(.*?)\s+<(.*)>\s*$/gim;
   const matches = [];
   let match;
   while ((match = regex.exec(comparisonCommit.message)) !== null) {


### PR DESCRIPTION
We had a few community contributions with this and it's always hard to spot and find out what the issue is, as the diff from the tool looks correct, even when copied out.

## Regex 101 view:
Notice the green `.` at the end of the first name

Before | After
---|---
<img width="773" height="243" alt="grafik" src="https://github.com/user-attachments/assets/f039ecb2-9d54-4b35-92b6-7ac23b74ea11" /> | <img width="773" height="243" alt="grafik" src="https://github.com/user-attachments/assets/997e2bf4-a194-4694-86ed-fefbd56afe7d" />



### Searching with 1 space (sign-off and expected hit)
<img width="1663" height="165" alt="grafik" src="https://github.com/user-attachments/assets/65670d50-a4b6-438d-b3d0-65287929f3b4" />


### Searching with 2 spaces (only real hit)
<img width="1663" height="165" alt="grafik" src="https://github.com/user-attachments/assets/0b7528cd-9991-4e0d-9f8d-f819c7e3a116" />
