### PR TITLE
CI: Add prek pre-commit configuration

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+# SPDX-License-Identifier: ISC
+[codespell]
+ignore-words-list = mergin,pinter,thirdparty
+skip = ./package-lock.json,./test/fixtures,./test/__snapshots__,./LICENSES,./node_modules,./coverage

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+# SPDX-License-Identifier: ISC
+
 # The ID of your GitHub App
 APP_ID=
 WEBHOOK_SECRET=development

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+# SPDX-License-Identifier: ISC
+
 ---
 version: 2
 updates:

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,2 +1,6 @@
+---
+# SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+# SPDX-License-Identifier: ISC
+
 # Configuration for https://github.com/probot/stale
 _extends: .github

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,7 @@
+---
+# SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+# SPDX-License-Identifier: ISC
+
 name: Release
 "on":
   push:
@@ -7,9 +11,10 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: lts/*
           cache: npm

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,4 +1,8 @@
-on:
+---
+# SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+# SPDX-License-Identifier: ISC
+
+"on":
   schedule:
     # https://crontab.guru/once-a-day
     - cron: 0 0 * * *
@@ -8,8 +12,9 @@ name: Stats
 jobs:
   stats:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: gr2m/app-stats-action@v1.x
+      - uses: gr2m/app-stats-action@d88119878fb9601fb30d0aa5805da7671cd1e39e  # v1.2.16
         id: stats
         with:
           id: ${{ secrets.DCO_APP_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,22 @@
+---
+# SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+# SPDX-License-Identifier: ISC
+
 name: Test
-on:
+"on":
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, synchronize]
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "lts/*"
           cache: npm

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+# SPDX-License-Identifier: ISC
+
 *.pem
 .DS_Store
 .env

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+# SPDX-License-Identifier: ISC
+
+[general]
+regex-style-search=true
+contrib=contrib-title-conventional-commits,contrib-body-requires-signed-off-by
+
+[title-max-length]
+line-length=50
+
+[body-max-line-length]
+line-length=72
+
+[ignore-by-body]
+regex=(.*)https?://(.*)
+ignore=body-max-line-length
+
+[contrib-title-conventional-commits]
+types=Fix,Feat,Chore,Docs,Style,Refactor,Perf,Test,Revert,CI,Build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,118 @@
+---
+# SPDX-License-Identifier: ISC
+# SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+
+ci:
+  # pre-commit.ci sandbox prevents network calls and has no Node
+  # toolchain; disable hooks that need either.
+  skip: [jest, gha-workflow-linter]
+  autofix_commit_msg: |
+    Chore: pre-commit autofixes
+
+    Signed-off-by: pre-commit-ci[bot] <pre-commit-ci@users.noreply.github.com>
+  autoupdate_commit_msg: |
+    Chore: pre-commit autoupdate
+
+    Signed-off-by: pre-commit-ci[bot] <pre-commit-ci@users.noreply.github.com>
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-added-large-files
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-xml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+      - id: no-commit-to-branch
+        args:
+          - --branch=main
+
+  - repo: https://github.com/jorisroovers/gitlint
+    rev: acc9d9de6369b76d22cb4167029d2035e8730b98  # frozen: v0.19.1
+    hooks:
+      - id: gitlint
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: cba56bcde1fdd01c1deb3f945e69764c291a6530  # frozen: v1.38.0
+    hooks:
+      - id: yamllint
+        types: [yaml]
+
+  - repo: https://github.com/btford/write-good
+    rev: ab66ce10136dfad5146e69e70f82a3efac8842c1  # frozen: v1.0.8
+    hooks:
+      - id: write-good
+        args: ["--no-passive", "--no-cliches"]
+        exclude: ^LICENSE\.md$
+        files: "\\.(rst|md|markdown|mdown|mkdn)$"
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: 2ccb47ff45ad361a21071a7eedda4c37e6ae8c5a  # frozen: v2.4.2
+    hooks:
+      - id: codespell
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: a4d5d37e66ebcd6b3705204a1d6dbb56dea66338  # frozen: v0.49.0
+    hooks:
+      - id: markdownlint
+        args: ["--fix"]
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: 745eface02aef23e168a8afb6b5737818efbea95  # frozen: v0.11.0.1
+    hooks:
+      - id: shellcheck
+
+  - repo: https://github.com/fsfe/reuse-tool
+    rev: 9fabf9eb815a57aac116b435e8346c200cdb8604  # frozen: v6.2.0
+    hooks:
+      - id: reuse
+
+  # Replaces: https://github.com/rhysd/actionlint
+  # Permits actionlint to run both locally and with pre-commit.ci/GitHub
+  - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
+    rev: c04ed26e40637cab1aa9879c693832a9c120fb20  # frozen: v1.7.12.24
+    hooks:
+      - id: actionlint
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 8ef330cbb7204d388aa7a620f9549bcea8009663  # frozen: 0.37.3
+    hooks:
+      - id: check-github-actions
+      - id: check-github-workflows
+      - id: check-jsonschema
+        name: Check GitHub Workflows set timeout-minutes
+        args:
+          - --builtin-schema
+          - github-workflows-require-timeout
+        files: ^\.github/workflows/[^/]+$
+        types:
+          - yaml
+      - id: check-dependabot
+
+  - repo: https://github.com/lfreleng-actions/gha-workflow-linter
+    rev: bfc5489483353425f8e023902d91c3ae3584f955  # frozen: v1.2.0
+    hooks:
+      - id: gha-workflow-linter
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: ea782651a7e32f40a3d13b76c79d5a2474ee8723  # frozen: v2.5.1
+    hooks:
+      - id: prettier
+        files: ^(index\.js|app\.yml|package\.json|(lib|test|docs)/.+\.(js|json))$
+
+  # Run the test suite last so any auto-fixes from earlier hooks are
+  # exercised. Tests need the full project dependency tree, so this
+  # stays a local hook and is skipped on pre-commit.ci.
+  - repo: local
+    hooks:
+      - id: jest
+        name: jest
+        entry: npm test
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+# SPDX-License-Identifier: ISC
+
+*.md

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,15 @@
+---
+# SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+# SPDX-License-Identifier: ISC
+
+extends: default
+
+rules:
+  empty-lines:
+    max-end: 1
+  comments:
+    # prettier forces 1 space comment separator
+    min-spaces-from-content: 1
+    level: error
+  line-length:
+    max: 120

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-ISC License
+# ISC License
 
 Copyright (c) [dcoapp/app contributors](https://github.com/dcoapp/app/graphs/contributors)
 

--- a/LICENSES/ISC.txt
+++ b/LICENSES/ISC.txt
@@ -1,0 +1,8 @@
+ISC License
+
+Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC")
+Copyright (c) 1995-2003 by Internet Software Consortium
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,42 @@
+<!--
+SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+SPDX-License-Identifier: ISC
+-->
+
 # Probot: DCO
 
-a GitHub Integration built with [probot](https://github.com/probot/probot) that enforces the [Developer Certificate of Origin](https://developercertificate.org/) (DCO) on Pull Requests. It requires all commit messages to contain the `Signed-off-by` line with an email address that matches the commit author.
+A GitHub Integration built with [probot](https://github.com/probot/probot)
+that enforces the [Developer Certificate of Origin][dco] (DCO) on Pull
+Requests. It requires all commit messages to contain the `Signed-off-by` line
+with an email address that matches the commit author.
 
 ## Usage
 
-[Configure the integration](https://github.com/apps/dco) for your organization or repositories. Enable [required status checks](docs/required-statuses.md) if you want to enforce the DCO on all commits.
+[Configure the integration](https://github.com/apps/dco) for your organization
+or repositories. Enable [required status checks](docs/required-statuses.md) if
+you want to enforce the DCO on all commits.
 
-See [docs/deploy.md](docs/deploy.md) if you would like to run your own instance of this plugin.
+See [docs/deploy.md](docs/deploy.md) if you would like to run your own
+instance of this plugin.
 
 ## Modes of operations
 
 ### Default
 
-By default, Probot DCO enforces the presence of [valid DCO signoffs](#how-it-works) on all commits (excluding bots and merges). If a PRs contains commits that lack a valid Signed-off-by line, they are blocked until a correctly signed-off revision of the commit is pushed. This closely mirrors the upstream Linux kernel process.
+By default, Probot DCO enforces the presence of [valid DCO
+signoffs](#how-it-works) on all commits (excluding bots and merges). If a PR
+contains commits that lack a valid Signed-off-by line, Probot DCO blocks it
+until someone pushes a signed-off revision of the commit. This mirrors the
+upstream Linux kernel process.
 
 ### Individual remediation commit support
 
-Optionally, a project can allow individual remediation commit support, where the failing commit's author can push an additional properly signed-off commit with additional text in the commit log that indicates they apply their signoff retroactively.
+A project can allow individual remediation commit support, where the failing
+commit's author can push a follow-up signed-off commit. Text in the commit log
+indicates that they apply their signoff retroactively.
 
-To enable this, place the following configuration file in `.github/dco.yml` on the default branch:
+To enable this, place the following configuration file in `.github/dco.yml` on
+the default branch:
 
 ```yaml
 allowRemediationCommits:
@@ -27,9 +45,13 @@ allowRemediationCommits:
 
 ### Third-party remediation support
 
-Additionally, a project can allow third-parties to sign off on an author's behalf by pushing an additional properly signed-off commit with additional text in the commit log that indicates they sign off on behalf of the author. Third-party remediation requires individual remediation to be enabled.
+A project can also allow third-parties to sign off on an author's behalf by
+pushing a follow-up signed-off commit. Text in the commit log indicates that
+they sign off on behalf of the author. Enable individual remediation before
+using third-party remediation.
 
-To enable this, place the following configuration file in `.github/dco.yml` on the default branch:
+To enable this, place the following configuration file in `.github/dco.yml` on
+the default branch:
 
 ```yaml
 allowRemediationCommits:
@@ -39,55 +61,84 @@ allowRemediationCommits:
 
 ### Skipping sign-off for organization members
 
-It is possible to disable the check for commits authored and [signed](https://help.github.com/articles/signing-commits-using-gpg/) by members of the organization the repository belongs to. To do this, place the following configuration file in `.github/dco.yml` on the default branch:
+To disable the check for commits authored and
+[signed](https://help.github.com/articles/signing-commits-using-gpg/) by
+members of the organization the repository belongs to, place the following
+configuration file in `.github/dco.yml` on the default branch:
 
 ```yaml
 require:
   members: false
 ```
 
-When this setting is present on a repository that belongs to a GitHub user (instead of an organization), only the repository owner is allowed to push commits without sign-off.
+When this setting is present on a repository that belongs to a GitHub user
+(instead of an organization), the repository owner can push commits without
+sign-off.
 
 ## How it works
 
-The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. Here is the full [text of the DCO](https://developercertificate.org/), reformatted for readability:
+The Developer Certificate of Origin (DCO) is a lightweight way for contributors
+to certify that they wrote or otherwise have the right to submit the code they
+are contributing to the project. Here is the full [text of the DCO][dco],
+reformatted for readability:
 
-> By making a contribution to this project, I certify that:
->
-> a. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
->
-> b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
->
-> c. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
->
-> d. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+```text
+By making a contribution to this project, I certify that:
 
-Contributors _sign-off_ that they adhere to these requirements by adding a `Signed-off-by` line to commit messages.
+a. The contribution was created in whole or in part by me and I have the right
+to submit it under the open source license indicated in the file; or
 
+b. The contribution is based upon previous work that, to the best of my
+knowledge, is covered under an appropriate open source license and I have the
+right under that license to submit that work with modifications, whether created
+in whole or in part by me, under the same open source license (unless I am
+permitted to submit under a different license), as indicated in the file; or
+
+c. The contribution was provided directly to me by some other person who
+certified (a), (b) or (c) and I have not modified it.
+
+d. I understand and agree that this project and the contribution are public and
+that a record of the contribution (including all personal information I submit
+with it, including my sign-off) is maintained indefinitely and may be
+redistributed consistent with this project or the open source license(s)
+involved.
 ```
+
+Contributors _sign-off_ that they adhere to these requirements by adding a
+`Signed-off-by` line to commit messages.
+
+```text
 This is my commit message
 
 Signed-off-by: Random J Developer <random@developer.example.org>
 ```
 
-Git even has a `-s` command line option to append this automatically to your commit message:
+Git even has a `-s` command line option to append this automatically to your
+commit message:
 
-```
-$ git commit -s -m 'This is my commit message'
+```console
+git commit -s -m 'This is my commit message'
 ```
 
-Once [installed](#usage), this integration will create a [check](https://developer.github.com/v3/checks/runs/) indicating whether or not commits in a Pull Request do not contain a valid `Signed-off-by` line.
+Once [installed](#usage), this integration will create a
+[check](https://developer.github.com/v3/checks/runs/) indicating whether
+commits in a Pull Request do not contain a valid `Signed-off-by` line.
 
 ![DCO success](https://user-images.githubusercontent.com/13410355/42352738-35f4e690-8071-11e8-9c8c-260e5868bfc8.png)
 ![DCO failure](https://user-images.githubusercontent.com/13410355/42352794-85fe1c9c-8071-11e8-834a-05a4aeb8cc90.png)
 
-Additionally, the DCO creates an override button accessible to only those with write access to the repository to create a successful check.
+The DCO also creates an override button for users with write access to the
+repository to create a successful check.
 
 ![DCO button](https://user-images.githubusercontent.com/13410355/42353254-3bfa266a-8074-11e8-80b4-18760c5efeee.png)
 
 ## Further Reading
 
-If you want to learn more about the DCO and why it might be necessary, here are some good resources:
+If you want to learn more about the DCO and why it might be necessary, here are
+some good resources:
 
-- [Developer Certificate of Origin versus Contributor License Agreements](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/)
+- Developer Certificate of Origin versus Contributor License Agreements:
+  <https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/>
 - [The most powerful contributor agreement](https://lwn.net/Articles/592503/)
+
+[dco]: https://developercertificate.org/

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,17 @@
+version = 1
+
+[[annotations]]
+path = [
+    "package.json",
+    "package-lock.json",
+    "test/__snapshots__/index.test.js.snap",
+    "test/fixtures/compare-success.json",
+    "test/fixtures/compare.json",
+    "test/fixtures/pull_request.opened-success.json",
+    "test/fixtures/pull_request.opened.json",
+    "test/fixtures/push.not-signed-off.json",
+    "test/fixtures/push.signed-off.json",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2018 - 2026 DCO App Contributors"
+SPDX-License-Identifier = "ISC"

--- a/api/github/webhooks/index.js
+++ b/api/github/webhooks/index.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+// SPDX-License-Identifier: ISC
+
 const { createNodeMiddleware, createProbot } = require('probot')
 
 const app = require('../../../')

--- a/app.yml
+++ b/app.yml
@@ -1,3 +1,7 @@
+---
+# SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+# SPDX-License-Identifier: ISC
+
 # This is a GitHub App Manifest. These settings will be used by default when
 # initially configuring your GitHub App.
 #
@@ -132,6 +136,7 @@ default_permissions:
 # A description of the GitHub App.
 # description: A description of my awesome app
 
-# Set to true when your GitHub App is available to the public or false when it is only accessible to the owner of the app.
+# Set to true when your GitHub App is available to the public or false when it
+# is only accessible to the owner of the app.
 # Default: true
 # public: false

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,5 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+SPDX-License-Identifier: ISC
+-->
+
 # Deploying
 
-If you would like to run your own instance of this GitHub, see the [Deployment docs](https://probot.github.io/docs/deployment/).
+If you would like to run your own instance of this GitHub App, see the
+[Deployment docs](https://probot.github.io/docs/deployment/).
 
-All required permissions and events are configured in [`app.yml`](../app.yml).
+The [`app.yml`](../app.yml) file configures all required permissions and events.

--- a/docs/required-statuses.md
+++ b/docs/required-statuses.md
@@ -1,9 +1,19 @@
+<!--
+SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+SPDX-License-Identifier: ISC
+-->
+
 # Required Status Checks
 
-Enable [required status checks](https://help.github.com/articles/about-required-status-checks/) if you want to enforce the DCO on all commits (you will need to open at least one Pull Request after configuring the integration before you can set this up).
+Enable [required status checks][required-status-checks] if you want to enforce
+the DCO on all commits. You need to open at least one Pull Request after
+configuring the integration before you can set this up.
 
-![](https://cloud.githubusercontent.com/assets/173/24323001/7013b7c0-113c-11e7-8ef6-8f6cb7539f33.png)
+![Branch protection rule settings](https://cloud.githubusercontent.com/assets/173/24323001/7013b7c0-113c-11e7-8ef6-8f6cb7539f33.png)
 
-![](https://cloud.githubusercontent.com/assets/173/24327690/5da657e4-119d-11e7-9f84-97d468db7b58.png)
+![Required DCO status check settings](https://cloud.githubusercontent.com/assets/173/24327690/5da657e4-119d-11e7-9f84-97d468db7b58.png)
 
-Now pushes to `master` will not be allowed, and all pull requests must pass the DCO checks before being merged.
+With required status checks enabled, all pull requests must pass the DCO checks
+before merging.
+
+[required-status-checks]: https://help.github.com/articles/about-required-status-checks/

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+// SPDX-License-Identifier: ISC
+
 const getDCOStatus = require("./lib/dco.js");
 const requireMembers = require("./lib/requireMembers.js");
 

--- a/lib/dco.js
+++ b/lib/dco.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+// SPDX-License-Identifier: ISC
+
 const validator = require("email-validator");
 
 // Returns a list containing failed commit error messages

--- a/lib/requireMembers.js
+++ b/lib/requireMembers.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+// SPDX-License-Identifier: ISC
+
 module.exports = function (requireForMembers, context) {
   // If members are required to sign-off, then always require sign-off
   if (requireForMembers) {

--- a/test/dco.test.js
+++ b/test/dco.test.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+// SPDX-License-Identifier: ISC
+
 /*
  * The tests in this file verify the functionality of Probot DCO. Because there are many ways to
  * write a signoff and many ways to misconfigure git, the goal is to flush out as many corner cases

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+// SPDX-License-Identifier: ISC
+
 const nock = require("nock");
 const { Probot, ProbotOctokitCore } = require("probot");
 


### PR DESCRIPTION
## Summary

Adopt the team's standard pre-commit tooling and bring the repository
into REUSE licensing compliance. This change is intentionally scoped to
tooling, metadata, and documentation — it makes **no dependency or
runtime logic changes** (the only edits to `index.js` and
`api/github/webhooks/index.js` are added SPDX comment headers), so a
Vercel redeploy rebuilds the existing locked dependency tree unchanged.

## What's included

- **Pre-commit config** (`.pre-commit-config.yaml`) runnable via `prek`
  locally and on pre-commit.ci, with standard hooks: pre-commit-hooks,
  gitlint, yamllint, codespell, markdownlint, write-good, shellcheck,
  actionlint, check-jsonschema, gha-workflow-linter, and reuse; prettier
  via the pinned v2.5.1 mirror; and a local Jest test hook (skipped on
  pre-commit.ci).
- **Companion lint configs**: `.gitlint` (strict Conventional Commits:
  title <=50, body <=72, sign-off required), `.yamllint`, `.codespellrc`,
  `.prettierignore`.
- **REUSE compliance**: SPDX headers on all source/config/doc files,
  `LICENSES/ISC.txt`, and `REUSE.toml` for generated/data files. The repo
  now passes `reuse lint` (REUSE 3.3).
- **Markdown cleanup** so docs pass markdownlint defaults.
- **Workflow hardening**: `timeout-minutes` added to every workflow job.

## Verification

- `prek run --all-files` is green.
- `npm test` passes (218 tests, 15 snapshots).
- `reuse lint` reports full compliance.
