### PR TITLE
CI: Add dependabot cooldown and PR limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,18 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    # Wait before opening a bump PR so we don't churn on a release
+    # that gets retracted or superseded shortly after it ships.
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 15
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    # Wait before opening a bump PR so we don't churn on a release
+    # that gets retracted or superseded shortly after it ships.
+    # This is required to satisfy the zizmor workflow auditing tool.
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 15


### PR DESCRIPTION
## Summary

Brings the Dependabot configuration in line with current best practices by
adding a `cooldown` period and an explicit `open-pull-requests-limit` to
**both** ecosystems the repository uses (`npm` and `github-actions`).

## What changed

`.github/dependabot.yml` — for each ecosystem:

- **`cooldown.default-days: 7`** — delays opening a version-bump PR for seven
  days so we avoid churning on a release that gets retracted or superseded
  shortly after it ships. For the `github-actions` ecosystem this also
  satisfies the [zizmor](https://github.com/woodruffw/zizmor) workflow
  auditing tool.
- **`open-pull-requests-limit: 15`** — caps concurrent Dependabot PRs per
  ecosystem.

## Notes

- No change to existing behaviour beyond the new throttling parameters; the
  weekly schedule and ecosystems are unchanged.
- Validated locally with the repository's `prek`/pre-commit hooks: the
  "Validate Dependabot Config (v2)" and `yamllint` checks pass.
