### PR TITLE
Fix: Use dynamic import for probot in handler

### DIFF
--- a/api/github/webhooks/index.js
+++ b/api/github/webhooks/index.js
@@ -1,21 +1,23 @@
 // SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
 // SPDX-License-Identifier: ISC
 
-const { createNodeMiddleware, createProbot } = require("probot");
-
 const app = require("../../../");
 
 let middlewareReady;
 
 function getMiddleware() {
   if (!middlewareReady) {
-    middlewareReady = createNodeMiddleware(app, {
-      probot: createProbot(),
-      webhooksPath: "/api/github/webhooks",
-    }).catch((error) => {
-      middlewareReady = undefined;
-      throw error;
-    });
+    middlewareReady = import("probot")
+      .then(({ createNodeMiddleware, createProbot }) =>
+        createNodeMiddleware(app, {
+          probot: createProbot(),
+          webhooksPath: "/api/github/webhooks",
+        })
+      )
+      .catch((error) => {
+        middlewareReady = undefined;
+        throw error;
+      });
   }
 
   return middlewareReady;

--- a/test/webhooks.test.js
+++ b/test/webhooks.test.js
@@ -6,10 +6,12 @@ const mockCreateNodeMiddleware = jest.fn();
 const mockCreateProbot = jest.fn();
 const mockProbot = {};
 
-jest.mock("probot", () => ({
+const mockProbotModuleFactory = jest.fn(() => ({
   createNodeMiddleware: mockCreateNodeMiddleware,
   createProbot: mockCreateProbot,
 }));
+
+jest.unstable_mockModule("probot", mockProbotModuleFactory);
 
 function loadHandler() {
   jest.resetModules();
@@ -19,15 +21,43 @@ function loadHandler() {
 describe("GitHub webhook serverless handler", () => {
   beforeEach(() => {
     mockMiddleware.mockClear();
+    mockProbotModuleFactory.mockClear();
     mockCreateNodeMiddleware.mockReset();
     mockCreateProbot.mockReset();
     mockCreateProbot.mockReturnValue(mockProbot);
+  });
+
+  test("loads Probot lazily through dynamic import", async () => {
+    mockCreateNodeMiddleware.mockResolvedValue(mockMiddleware);
+
+    const handler = loadHandler();
+    const req = {};
+    const res = {};
+    const next = jest.fn();
+
+    expect(mockProbotModuleFactory).not.toHaveBeenCalled();
+    expect(mockCreateProbot).not.toHaveBeenCalled();
+    expect(mockCreateNodeMiddleware).not.toHaveBeenCalled();
+
+    await expect(handler(req, res, next)).resolves.toStrictEqual({
+      req,
+      res,
+      next,
+    });
+
+    expect(mockProbotModuleFactory).toHaveBeenCalledTimes(1);
+    expect(mockCreateProbot).toHaveBeenCalledTimes(1);
+    expect(mockCreateNodeMiddleware).toHaveBeenCalledTimes(1);
   });
 
   test("delegates requests to the Probot middleware", async () => {
     mockCreateNodeMiddleware.mockResolvedValue(mockMiddleware);
 
     const handler = loadHandler();
+    expect(mockProbotModuleFactory).not.toHaveBeenCalled();
+    expect(mockCreateProbot).not.toHaveBeenCalled();
+    expect(mockCreateNodeMiddleware).not.toHaveBeenCalled();
+
     const app = require("..");
     const req = {};
     const res = {};
@@ -50,10 +80,38 @@ describe("GitHub webhook serverless handler", () => {
     expect(mockMiddleware).toHaveBeenCalledWith(req, res, next);
   });
 
+  test("shares middleware initialization across concurrent requests", async () => {
+    mockCreateNodeMiddleware.mockResolvedValue(mockMiddleware);
+
+    const handler = loadHandler();
+    const req1 = {};
+    const res1 = {};
+    const next1 = jest.fn();
+    const req2 = {};
+    const res2 = {};
+    const next2 = jest.fn();
+
+    await expect(
+      Promise.all([handler(req1, res1, next1), handler(req2, res2, next2)])
+    ).resolves.toStrictEqual([
+      { req: req1, res: res1, next: next1 },
+      { req: req2, res: res2, next: next2 },
+    ]);
+
+    expect(mockProbotModuleFactory).toHaveBeenCalledTimes(1);
+    expect(mockCreateProbot).toHaveBeenCalledTimes(1);
+    expect(mockCreateNodeMiddleware).toHaveBeenCalledTimes(1);
+    expect(mockMiddleware).toHaveBeenCalledTimes(2);
+    expect(mockMiddleware).toHaveBeenCalledWith(req1, res1, next1);
+    expect(mockMiddleware).toHaveBeenCalledWith(req2, res2, next2);
+  });
+
   test("retries middleware initialization after a failure", async () => {
     const error = new Error("middleware failed");
     mockCreateNodeMiddleware
-      .mockReturnValueOnce(Promise.reject(error))
+      .mockImplementationOnce(() => {
+        throw error;
+      })
       .mockResolvedValueOnce(mockMiddleware);
 
     const handler = loadHandler();
@@ -69,6 +127,7 @@ describe("GitHub webhook serverless handler", () => {
     });
 
     expect(mockCreateNodeMiddleware).toHaveBeenCalledTimes(2);
+    expect(mockCreateProbot).toHaveBeenCalledTimes(2);
     expect(mockMiddleware).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

This fixes the production outage introduced after #275: probot 14 is
ESM-only, and Vercel's serverless runtime rejects require()-of-ESM. The
deployed webhook function then fails at startup with ERR_REQUIRE_ESM.
Production is temporarily mitigated by a manual Vercel rollback, but this
PR is the forward fix so the next deploy does not reintroduce the outage.

## Fix

- Lazily load probot with dynamic `import("probot")` in
  `api/github/webhooks/index.js`.
- Preserve the memoized middleware initialization promise.
- Preserve the error-reset behavior so a failed initialization can retry.
- Keep the app in CommonJS; this does NOT convert the app to ESM.

## Tests

- Hardened webhook tests to rely on the ESM dynamic-import mock only.
- Added an explicit lazy-load regression guard so probot is not loaded at
  module require-time.
- Added a concurrent cold-start memoization test.
- Confirmed Node 24 `npm test` passes with 100% coverage, including
  `api/github/webhooks/index.js`.

Please merge and redeploy to replace the rollback mitigation with the
forward production fix.

Closes #277