### PR TITLE
CI: Add Vercel preview deployment smoke tests

### DIFF
--- a/.github/workflows/smoke-preview.yml
+++ b/.github/workflows/smoke-preview.yml
@@ -1,0 +1,104 @@
+---
+# SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+# SPDX-License-Identifier: ISC
+
+name: Smoke Vercel deployment
+"on": deployment_status
+
+# This is a module-load smoke test for Vercel deployments. It calls a
+# separate, credential-free health function to catch Probot ESM/module-load
+# regressions, such as ERR_REQUIRE_ESM, without GitHub App credentials that
+# fork previews lack. It does not fully validate the webhook function bundle
+# or exercise credentialed boot; see the production-only webhook TODO below.
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    if: >-
+      github.event.deployment_status.state == 'success' &&
+      (endsWith(github.event.deployment_status.target_url, '.vercel.app') ||
+      contains(github.event.deployment_status.target_url, '.vercel.app/') ||
+      endsWith(github.event.deployment_status.environment_url, '.vercel.app') ||
+      contains(github.event.deployment_status.environment_url, '.vercel.app/'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Vercel's green build check does not invoke the serverless function.
+      # Polling this credential-free endpoint catches runtime module-load
+      # failures, such as ERR_REQUIRE_ESM, without GitHub App credentials that
+      # fork preview deployments intentionally do not receive.
+      - name: Smoke credential-free health endpoint
+        env:
+          DEPLOYMENT_ENVIRONMENT_URL: >-
+            ${{ github.event.deployment_status.environment_url }}
+          DEPLOYMENT_TARGET_URL: >-
+            ${{ github.event.deployment_status.target_url }}
+        run: |
+          set -euo pipefail
+
+          vercel_url() {
+            local url="$1"
+            local host
+
+            host="${url#*://}"
+            host="${host%%/*}"
+            host="${host%%:*}"
+            if [[ "$host" == *.vercel.app ]]; then
+              printf '%s' "$url"
+              return 0
+            fi
+
+            return 1
+          }
+
+          if deployment_url="$(vercel_url "$DEPLOYMENT_TARGET_URL")"; then
+            :
+          elif deployment_url="$(vercel_url "$DEPLOYMENT_ENVIRONMENT_URL")"; then
+            :
+          else
+            echo "::error::deployment_status did not include a Vercel URL"
+            exit 1
+          fi
+
+          deployment_url="${deployment_url%/}"
+          case "$deployment_url" in
+            https://*) ;;
+            *)
+              echo "::error::Vercel deployment URL must use HTTPS"
+              exit 1
+              ;;
+          esac
+
+          health_url="$deployment_url/api/health"
+          response_body="$PWD/health-response.json"
+
+          echo "Smoking $health_url"
+          for attempt in 1 2 3 4 5; do
+            : > "$response_body"
+            set +e
+            status_code="$(curl --silent --show-error --proto '=https' \
+              --connect-timeout 10 --max-time 30 --max-redirs 0 \
+              --max-filesize 1000000 --output "$response_body" \
+              --write-out "%{http_code}" "$health_url")"
+            curl_status=$?
+            set -e
+
+            echo "Attempt $attempt returned HTTP $status_code"
+            head -c 2000 "$response_body" || true
+            echo
+
+            if [ "$curl_status" -eq 0 ] && [ "$status_code" = "200" ]; then
+              exit 0
+            fi
+
+            sleep 10
+          done
+
+          echo "::error::Health endpoint did not return HTTP 200"
+          exit 1
+
+  # TODO: Add a production-only unsigned webhook smoke test once Vercel's exact
+  # production deployment_status environment name is confirmed. A healthy boot
+  # should return a non-5xx response for the missing webhook signature.

--- a/api/health.js
+++ b/api/health.js
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+// SPDX-License-Identifier: ISC
+
+module.exports = async (req, res) => {
+  try {
+    require("./github/webhooks/index.js");
+    await import("probot");
+
+    res.statusCode = 200;
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ status: "ok" }));
+  } catch (error) {
+    console.error(error);
+    res.statusCode = 500;
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ status: "error", error: "health check failed" }));
+  }
+};

--- a/test/health.test.js
+++ b/test/health.test.js
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+// SPDX-License-Identifier: ISC
+
+const mockWebhookHandler = jest.fn();
+const mockWebhookModuleFactory = jest.fn(() => mockWebhookHandler);
+const mockProbotModuleFactory = jest.fn(() => ({}));
+
+jest.mock("../api/github/webhooks/index.js", () => mockWebhookModuleFactory());
+jest.unstable_mockModule("probot", mockProbotModuleFactory);
+
+function loadHandler() {
+  jest.resetModules();
+  return require("../api/health.js");
+}
+
+function createResponse() {
+  const res = {
+    statusCode: undefined,
+    setHeader: jest.fn(),
+    end: jest.fn(),
+  };
+
+  return res;
+}
+
+describe("credential-free health endpoint", () => {
+  beforeEach(() => {
+    mockWebhookHandler.mockClear();
+    mockWebhookModuleFactory.mockClear();
+    mockWebhookModuleFactory.mockReturnValue(mockWebhookHandler);
+    mockProbotModuleFactory.mockReset();
+    mockProbotModuleFactory.mockReturnValue({});
+  });
+
+  test("reports ok when runtime modules load", async () => {
+    const handler = loadHandler();
+    const req = {};
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(mockWebhookModuleFactory).toHaveBeenCalledTimes(1);
+    expect(mockProbotModuleFactory).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "content-type",
+      "application/json"
+    );
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ status: "ok" }));
+  });
+
+  test("reports errors when a runtime module fails to load", async () => {
+    const error = new Error("probot import failed");
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mockProbotModuleFactory.mockImplementation(() => {
+      throw error;
+    });
+
+    try {
+      const handler = loadHandler();
+      const req = {};
+      const res = createResponse();
+
+      await handler(req, res);
+
+      expect(consoleError).toHaveBeenCalledWith(error);
+      expect(res.statusCode).toBe(500);
+      expect(res.setHeader).toHaveBeenCalledWith(
+        "content-type",
+        "application/json"
+      );
+      expect(res.end).toHaveBeenCalledWith(
+        JSON.stringify({ status: "error", error: "health check failed" })
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Vercel's green build check only proves that the deployment built; it does not
invoke the serverless runtime. Recent Probot 14 module-load regressions caused
runtime boot outages that CI and the green Vercel build did not catch
(#277/#280).

This adds:

- a credential-free `/api/health` Vercel function that loads the webhook module
  and dynamically imports `probot`
- a `deployment_status` workflow that polls `/api/health` on successful Vercel
  preview deployments and fails if it does not return HTTP 200
- tests covering the health endpoint success and error paths at 100% coverage

Fork preview deployments intentionally do not receive GitHub App credentials, so
this smoke test avoids `createProbot()` and does not require `APP_ID`, private
key, or webhook secret.

## Scope / limits

This is a module-load smoke test for a separate credential-free health function.
It catches Probot ESM and module-load regressions such as `ERR_REQUIRE_ESM`, but
it does not fully validate the webhook function bundle or exercise credentialed
boot. A future production-only unsigned-webhook probe can extend coverage once
Vercel's production deployment environment name is confirmed.

The Vercel deployment smoke check is gated to Vercel deployment URLs and may be
org-gated for fork PRs.

Closes #279
