### PR TITLE
Build: Replace Prettier with Biome

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,11 +99,12 @@ repos:
     hooks:
       - id: gha-workflow-linter
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: ea782651a7e32f40a3d13b76c79d5a2474ee8723  # frozen: v2.5.1
+  - repo: https://github.com/biomejs/pre-commit
+    rev: 53525e29648f6e0d6a7b0cfaa67276478d3b1906  # frozen: v2.5.2
     hooks:
-      - id: prettier
-        files: ^(index\.js|app\.yml|package\.json|(lib|test|docs)/.+\.(js|json))$
+      - id: biome-format
+        additional_dependencies: ["@biomejs/biome@2.5.2"]
+        files: ^(biome\.jsonc|index\.js|package\.json|(lib|test|docs)/.+\.(js|json))$
 
   # Run the test suite last so any auto-fixes from earlier hooks are
   # exercised. Tests need the full project dependency tree, so this

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2018 - 2026 DCO App Contributors
+// SPDX-License-Identifier: ISC
+
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "files": {
+    "ignoreUnknown": true,
+    "includes": [
+      "biome.jsonc",
+      "index.js",
+      "package.json",
+      "lib/**/*.js",
+      "lib/**/*.json",
+      "test/**/*.js",
+      "test/**/*.json",
+      "docs/**/*.js",
+      "docs/**/*.json"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80
+  },
+  "linter": {
+    "enabled": false
+  },
+  "javascript": {
+    "formatter": {
+      "enabled": true,
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "es5"
+    }
+  },
+  "json": {
+    "formatter": {
+      "enabled": true,
+      "trailingCommas": "none"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
       "dependencies": {
         "@sentry/node": "^9.43.0",
         "email-validator": "^2.0.3",
-        "prettier": "^2.5.1",
         "probot": "^14.3.2"
       },
       "devDependencies": {
+        "@biomejs/biome": "2.5.2",
         "jest": "^30.4.2",
         "nock": "^14.0.0",
         "smee-client": "^1.0.1"
@@ -518,6 +518,169 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.2.tgz",
+      "integrity": "sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.5.2",
+        "@biomejs/cli-darwin-x64": "2.5.2",
+        "@biomejs/cli-linux-arm64": "2.5.2",
+        "@biomejs/cli-linux-arm64-musl": "2.5.2",
+        "@biomejs/cli-linux-x64": "2.5.2",
+        "@biomejs/cli-linux-x64-musl": "2.5.2",
+        "@biomejs/cli-win32-arm64": "2.5.2",
+        "@biomejs/cli-win32-x64": "2.5.2"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.2.tgz",
+      "integrity": "sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.2.tgz",
+      "integrity": "sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.2.tgz",
+      "integrity": "sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.2.tgz",
+      "integrity": "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -5587,20 +5750,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/prettier": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
-      "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
@@ -7260,6 +7409,78 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@biomejs/biome": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.2.tgz",
+      "integrity": "sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==",
+      "dev": true,
+      "requires": {
+        "@biomejs/cli-darwin-arm64": "2.5.2",
+        "@biomejs/cli-darwin-x64": "2.5.2",
+        "@biomejs/cli-linux-arm64": "2.5.2",
+        "@biomejs/cli-linux-arm64-musl": "2.5.2",
+        "@biomejs/cli-linux-x64": "2.5.2",
+        "@biomejs/cli-linux-x64-musl": "2.5.2",
+        "@biomejs/cli-win32-arm64": "2.5.2",
+        "@biomejs/cli-win32-x64": "2.5.2"
+      }
+    },
+    "@biomejs/cli-darwin-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-darwin-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.2.tgz",
+      "integrity": "sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.2.tgz",
+      "integrity": "sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.2.tgz",
+      "integrity": "sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-win32-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.2.tgz",
+      "integrity": "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-win32-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==",
+      "dev": true,
+      "optional": true
     },
     "@emnapi/core": {
       "version": "1.10.0",
@@ -10688,11 +10909,6 @@
       "requires": {
         "xtend": "^4.0.0"
       }
-    },
-    "prettier": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
-      "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw=="
     },
     "pretty-format": {
       "version": "30.4.1",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "start": "probot run ./index.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
     "posttest": "npm run lint",
-    "lint": "prettier --check '{lib,test,docs}/**/*.{js,json,md}' index.js *.md package.json app.yml",
-    "lint:fix": "prettier --write '{lib,test,docs}/**/*.{js,json,md}' index.js *.md package.json app.yml"
+    "lint": "biome check --linter-enabled=false --assist-enabled=false .",
+    "lint:fix": "biome format --write ."
   },
   "engines": {
     "node": "24.x"
@@ -19,10 +19,10 @@
   "dependencies": {
     "@sentry/node": "^9.43.0",
     "email-validator": "^2.0.3",
-    "prettier": "^2.5.1",
     "probot": "^14.3.2"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.5.2",
     "jest": "^30.4.2",
     "nock": "^14.0.0",
     "smee-client": "^1.0.1"


### PR DESCRIPTION
## Summary

Replace Prettier with Biome 2 for formatter-only JavaScript and JSON checks.
The archived `pre-commit/mirrors-prettier` hook is replaced with
`biomejs/pre-commit`'s `biome-format` hook, and Biome linting remains disabled
for now so this is only a formatter swap.

This intentionally narrows the npm `lint` / `posttest` formatter gate to the
files Biome formats in this repository: JavaScript and JSON. The previous
Prettier npm scripts and pre-commit hook also covered Markdown and `app.yml`;
those are no longer formatted by npm/Prettier in this PR, and no YAML formatter
is added here.

Markdown, YAML, and workflow validation remain enforced by the dedicated
pre-commit hooks via pre-commit.ci:

- `markdownlint` for Markdown formatting/style
- `yamllint` and `check-yaml` for YAML
- `actionlint` and check-jsonschema hooks for GitHub workflows

Biome does not format Markdown or YAML.

The Vercel preview check is organization-gated for fork PRs and may need
maintainer authorization before it can run. The Smoke Vercel deployment
startup_failure on this fork PR is a known pre-existing workflow issue tracked
separately.

Supersedes #263.
Closes #276.

## Validation

- `npm test` (225 tests, 100% coverage)
- `pre-commit run --all-files`
- `pre-commit run biome-format --files biome.jsonc`
