### PR TITLE
Feat: Add @dcoapp recheck comment command

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ Once [installed](#usage), this integration will create a
 [check](https://developer.github.com/v3/checks/runs/) indicating whether
 commits in a Pull Request do not contain a valid `Signed-off-by` line.
 
+Comment `@dcoapp recheck` on an open Pull Request to re-run or create the DCO
+check, which can recover PRs stuck waiting for status after an outage.
+
 ![DCO success](https://user-images.githubusercontent.com/13410355/42352738-35f4e690-8071-11e8-9c8c-260e5868bfc8.png)
 ![DCO failure](https://user-images.githubusercontent.com/13410355/42352794-85fe1c9c-8071-11e8-834a-05a4aeb8cc90.png)
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -9,6 +9,7 @@ path = [
     "test/__snapshots__/index.test.js.snap",
     "test/fixtures/compare-success.json",
     "test/fixtures/compare.json",
+    "test/fixtures/issue_comment.created.json",
     "test/fixtures/pull_request.opened-success.json",
     "test/fixtures/pull_request.opened.json",
     "test/fixtures/push.not-signed-off.json",

--- a/app.yml
+++ b/app.yml
@@ -26,7 +26,7 @@ default_events:
   # - deployment_status
   # - fork
   # - gollum
-  # - issue_comment
+  - issue_comment
   # - issues
   # - label
   # - milestone

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = (app) => {
     check
   );
 
-  async function check(context) {
+  async function check(context, pr = context.payload.pull_request) {
     const timeStart = new Date();
 
     const config = await context.config("dco.yml", {
@@ -32,8 +32,6 @@ module.exports = (app) => {
     const requireForMembers = config.require.members;
     const allowRemediationCommits = config.allowRemediationCommits;
 
-    const pr = context.payload.pull_request;
-
     const compare = await context.octokit.rest.repos.compareCommits(
       context.repo({
         base: pr.base.sha,
@@ -45,7 +43,7 @@ module.exports = (app) => {
     const dcoFailed = await getDCOStatus(
       commits,
       requireMembers(requireForMembers, context),
-      context.payload.pull_request.html_url,
+      pr.html_url,
       allowRemediationCommits
     );
 
@@ -143,6 +141,20 @@ module.exports = (app) => {
           );
         });
     }
+  }
+
+  app.on("issue_comment.created", onRecheckComment);
+  async function onRecheckComment(context) {
+    const { comment, issue } = context.payload;
+    if (!issue.pull_request) return;
+    if (comment.user.type === "Bot") return;
+    if (issue.state !== "open") return;
+    if (comment.body.trim().toLowerCase() !== "@dcoapp recheck") return;
+
+    const { data: pr } = await context.octokit.rest.pulls.get(
+      context.repo({ pull_number: issue.number })
+    );
+    await check(context, pr);
   }
 
   // This option is only presented to users with Write Access to the repo

--- a/test/fixtures/issue_comment.created.json
+++ b/test/fixtures/issue_comment.created.json
@@ -1,0 +1,34 @@
+{
+  "action": "created",
+  "issue": {
+    "number": 1,
+    "state": "open",
+    "pull_request": {
+      "url": "https://api.github.com/repos/octocat/Hello-World/pulls/1",
+      "html_url": "https://github.com/octocat/Hello-World/pull/1",
+      "diff_url": "https://github.com/octocat/Hello-World/pull/1.diff",
+      "patch_url": "https://github.com/octocat/Hello-World/pull/1.patch"
+    }
+  },
+  "comment": {
+    "id": 123456,
+    "body": "@dcoapp recheck",
+    "user": {
+      "login": "octocat",
+      "type": "User"
+    }
+  },
+  "repository": {
+    "name": "Hello-World",
+    "full_name": "octocat/Hello-World",
+    "owner": {
+      "login": "octocat",
+      "type": "User"
+    },
+    "default_branch": "master"
+  },
+  "sender": {
+    "login": "octocat",
+    "type": "User"
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,6 +7,7 @@ const dco = require("..");
 
 const payload = require("./fixtures/pull_request.opened");
 const payloadSuccess = require("./fixtures/pull_request.opened-success");
+const issueCommentPayload = require("./fixtures/issue_comment.created");
 const compare = require("./fixtures/compare");
 const compareSuccess = require("./fixtures/compare-success");
 
@@ -539,6 +540,83 @@ allowRemediationCommits:
           },
         },
       });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+  });
+
+  describe("issue_comment.created event", () => {
+    test("ignores comments that are not on a pull request", async () => {
+      const payload = structuredClone(issueCommentPayload);
+      delete payload.issue.pull_request;
+
+      await probot.receive({ name: "issue_comment", payload });
+    });
+
+    test("ignores comments from bots", async () => {
+      const payload = structuredClone(issueCommentPayload);
+      payload.comment.user.type = "Bot";
+
+      await probot.receive({ name: "issue_comment", payload });
+    });
+
+    test("ignores comments on closed pull requests", async () => {
+      const payload = structuredClone(issueCommentPayload);
+      payload.issue.state = "closed";
+
+      await probot.receive({ name: "issue_comment", payload });
+    });
+
+    test("ignores comments without the exact recheck command", async () => {
+      const payload = structuredClone(issueCommentPayload);
+      payload.comment.body = "@dcoapp recheck please";
+
+      await probot.receive({ name: "issue_comment", payload });
+    });
+
+    test("creates a passing check for recheck comments", async () => {
+      const payload = structuredClone(issueCommentPayload);
+      payload.comment.body = "  @DCOApp Recheck ";
+      const pullRequest = {
+        ...payloadSuccess.pull_request,
+        closed_at: null,
+        state: "open",
+      };
+
+      const mock = nock("https://api.github.com")
+        .get("/repos/octocat/Hello-World/pulls/1")
+        .reply(200, pullRequest)
+        // no config
+        .get("/repos/octocat/Hello-World/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/octocat/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get(
+          "/repos/octocat/Hello-World/compare/a10867b14bb761a232cd80139fbd4c0d33264240...34c5c7793cb3b279e22454cb6750c80560547b3a"
+        )
+        .reply(200, compareSuccess)
+
+        .post("/repos/octocat/Hello-World/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "success",
+            head_branch: "changes",
+            head_sha: "34c5c7793cb3b279e22454cb6750c80560547b3a",
+            name: "DCO",
+            output: {
+              summary: "All commits are signed off!",
+              title: "DCO",
+            },
+            status: "completed",
+          });
+
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "issue_comment", payload });
 
       expect(mock.activeMocks()).toStrictEqual([]);
     });


### PR DESCRIPTION
## Summary

Adds an `@dcoapp recheck` issue comment command for open pull requests. Commenting the exact command on an open PR re-runs or first-creates the DCO check, primarily for outage recovery when a PR is stuck \"Waiting for status\" and has no UI re-run button.

## Design

- Anyone may trigger the command.
- The command is an exact trimmed, case-insensitive match.
- Only created comments on open PRs are handled.
- Bot comments are ignored.
- The app does not post an acknowledgement, avoiding any new write permission.
- Refactors `check(context, pr)` so pull request events keep using the payload PR while the comment handler can fetch and pass the PR explicitly.

This only adds the `issue_comment` event subscription. GitHub's `issue_comment` event is already covered by the existing `pull_requests: read` permission for PR comments, so there is no new permission scope and existing installations do not need to re-approve. They only need the \"Issue comment\" event enabled in the GitHub App settings.

Closes #283