### PR TITLE
Fix: Report DCO check when compare API fails

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -7,6 +7,7 @@ path = [
     "package.json",
     "package-lock.json",
     "test/__snapshots__/index.test.js.snap",
+    "test/fixtures/check_run.rerequested.json",
     "test/fixtures/compare-success.json",
     "test/fixtures/compare.json",
     "test/fixtures/pull_request.opened-success.json",

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -22,7 +22,7 @@ entries under **Repository permissions** and lists **Members** under
 | Permission | Scope | Access | Why it's needed |
 | --- | --- | --- | --- |
 | Checks | Repository | Write | Creates the `DCO` check run and handles the manual "Set DCO to pass" check-run action. |
-| Contents | Repository | Read | Reads commits with `compareCommits` so the app can check sign-offs. |
+| Contents | Repository | Read | Reads repository configuration and merge-queue commit ranges so the app can check sign-offs. |
 | Metadata | Repository | Read | Required baseline permission for all GitHub Apps. |
 | Merge queues | Repository | Read | Receives `merge_group` deliveries for merge queues. |
 | Pull requests | Repository | Read | Reads pull request details and handles pull-request, review, and review-comment events. |

--- a/index.js
+++ b/index.js
@@ -8,14 +8,7 @@ const requireMembers = require("./lib/requireMembers.js");
  * @param {import('probot').Probot} app
  */
 module.exports = (app) => {
-  app.on(
-    [
-      "pull_request.opened",
-      "pull_request.synchronize",
-      "check_run.rerequested",
-    ],
-    check
-  );
+  app.on(["pull_request.opened", "pull_request.synchronize"], check);
 
   async function check(
     context,
@@ -55,13 +48,6 @@ module.exports = (app) => {
           context.octokit.rest.pulls.listCommits,
           context.repo({ pull_number: pr.number, per_page: 100 })
         );
-        /* istanbul ignore if -- exercised by check_run.rerequested */
-        if (pr.head.sha !== sha) {
-          context.log.info(
-            `pull request head changed from ${sha} to ${pr.head.sha}; skipping stale DCO report`
-          );
-          return;
-        }
         if (commits.length === 0) {
           await reportDCO(context, {
             sha,
@@ -157,7 +143,6 @@ module.exports = (app) => {
   ) {
     const params = {
       name: "DCO",
-      head_branch: ref,
       head_sha: sha,
       status: "completed",
       started_at: timeStart,
@@ -168,6 +153,7 @@ module.exports = (app) => {
         summary,
       },
     };
+    if (ref) params.head_branch = ref;
     if (actions) params.actions = actions;
 
     try {
@@ -240,6 +226,71 @@ Please retry by re-running the check or pushing a new commit.`;
       headSha: mergeGroup.head_sha,
     });
   });
+
+  app.on("check_run.rerequested", onCheckRunRerequested);
+  async function onCheckRunRerequested(context) {
+    const checkRun = context.payload.check_run;
+    const ref = checkRun.check_suite.head_branch;
+    const pullRequest = checkRun.pull_requests[0];
+
+    if (!pullRequest) {
+      await reportDCO(context, {
+        sha: checkRun.head_sha,
+        ref,
+        timeStart: new Date(),
+        conclusion: "failure",
+        summary:
+          "The DCO check could not be evaluated because this check run is not associated with a pull request.\n\nPlease retry by pushing a new commit or opening a pull request with this commit.",
+        statusDescription: "DCO check is not associated with a pull request.",
+      });
+      return;
+    }
+
+    let pr;
+    try {
+      ({ data: pr } = await context.octokit.rest.pulls.get(
+        context.repo({ pull_number: pullRequest.number })
+      ));
+    } catch (error) {
+      context.log.error(
+        error,
+        `check_run: could not fetch PR #${pullRequest.number}`
+      );
+      await reportDCO(context, {
+        sha: checkRun.head_sha,
+        ref,
+        timeStart: new Date(),
+        conclusion: "failure",
+        summary: `The DCO check could not be evaluated because pull request #${pullRequest.number} could not be fetched.
+
+Please retry by re-running the check or pushing a new commit.`,
+        statusDescription: `Could not fetch PR #${pullRequest.number}.`,
+      });
+      return;
+    }
+
+    if (pr.head.sha !== checkRun.head_sha) {
+      await reportDCO(context, {
+        sha: checkRun.head_sha,
+        ref,
+        timeStart: new Date(),
+        conclusion: "neutral",
+        summary: `This DCO check was re-run for a commit that has been superseded by the current pull request head.
+
+Current pull request head: ${pr.head.sha}
+
+Please use the DCO check on the current pull request head, or push a new commit to trigger a fresh check.`,
+        statusState: "success",
+        statusDescription: "This commit has been superseded.",
+      });
+      return;
+    }
+
+    await check(context, pr, {
+      reportSha: checkRun.head_sha,
+      reportRef: ref,
+    });
+  }
 
   function isRecheckCommand(body) {
     if (!body) return false;

--- a/index.js
+++ b/index.js
@@ -195,10 +195,24 @@ Please retry by re-running the check or pushing a new commit.`;
 
   app.on("merge_group.checks_requested", async (context) => {
     const mergeGroup = context.payload.merge_group;
+    const reportSha = mergeGroup.head_sha;
+    const reportRef = mergeGroup.head_ref.replace(/^refs\/heads\//, "");
     const match = mergeGroup.head_ref.match(
       /(?:^|\/)gh-readonly-queue\/.+\/pr-(\d+)-/
     );
-    if (!match) return;
+    if (!match) {
+      await reportDCO(context, {
+        sha: reportSha,
+        ref: reportRef,
+        timeStart: new Date(),
+        conclusion: "failure",
+        summary: `The DCO check could not be evaluated because the merge group head ref has an unrecognized format: ${mergeGroup.head_ref}.
+
+A maintainer can retry the merge queue entry. If this keeps happening, please report the merge group payload to the DCO app maintainers.`,
+        statusDescription: "Unrecognized merge group head ref.",
+      });
+      return;
+    }
     const prNumber = parseInt(match[1], 10);
 
     let pr;
@@ -207,19 +221,30 @@ Please retry by re-running the check or pushing a new commit.`;
         context.repo({ pull_number: prNumber })
       ));
     } catch (error) {
-      if (error.status === 404 || error.status === 403) {
-        context.log.info(
-          `merge_group: could not fetch PR #${prNumber}: ${error.message}`
-        );
-        return;
-      }
-      throw error;
+      context.log.error(error, `merge_group: could not fetch PR #${prNumber}`);
+      const reason =
+        error.status === 404
+          ? `pull request #${prNumber} was not found`
+          : error.status === 403
+            ? `pull request #${prNumber} could not be accessed`
+            : `pull request #${prNumber} could not be fetched`;
+      await reportDCO(context, {
+        sha: reportSha,
+        ref: reportRef,
+        timeStart: new Date(),
+        conclusion: "failure",
+        summary: `The DCO check could not be evaluated because ${reason}.
+
+A maintainer can retry the merge queue entry after confirming the pull request still exists and the DCO app can access it.`,
+        statusDescription: `Could not fetch PR #${prNumber}.`,
+      });
+      return;
     }
 
     await check(context, pr, {
       // Report the check result on the merge group's temporary merge commit.
-      reportSha: mergeGroup.head_sha,
-      reportRef: mergeGroup.head_ref,
+      reportSha,
+      reportRef,
       // Compare the full merge group range so all batched PRs are validated.
       // headSha equals reportSha: both target the merge group head commit.
       baseSha: mergeGroup.base_sha,

--- a/index.js
+++ b/index.js
@@ -26,67 +26,86 @@ module.exports = (app) => {
     const sha = reportSha || pr.head.sha;
     const ref = (reportRef || pr.head.ref).replace(/^refs\/heads\//, "");
 
-    const config = await context.config("dco.yml", {
-      require: {
-        members: true,
-      },
-      allowRemediationCommits: {
-        individual: false,
-        thirdParty: false,
-      },
-    });
-    const requireForMembers = config.require.members;
-    const allowRemediationCommits = config.allowRemediationCommits;
+    let commits;
+    let dcoFailed;
+    let allowRemediationCommits;
+    try {
+      const config = await context.config("dco.yml", {
+        require: {
+          members: true,
+        },
+        allowRemediationCommits: {
+          individual: false,
+          thirdParty: false,
+        },
+      });
+      const requireForMembers = config.require.members;
+      allowRemediationCommits = config.allowRemediationCommits;
 
-    const compare = await context.octokit.rest.repos.compareCommits(
-      context.repo({
-        base: baseSha || pr.base.sha,
-        head: headSha || pr.head.sha,
-      })
-    );
+      if (baseSha && headSha) {
+        const compare = await context.octokit.rest.repos.compareCommits(
+          context.repo({
+            base: baseSha,
+            head: headSha,
+          })
+        );
+        commits = compare.data.commits;
+      } else {
+        commits = await context.octokit.paginate(
+          context.octokit.rest.pulls.listCommits,
+          context.repo({ pull_number: pr.number, per_page: 100 })
+        );
+        /* istanbul ignore if -- exercised by check_run.rerequested */
+        if (pr.head.sha !== sha) {
+          context.log.info(
+            `pull request head changed from ${sha} to ${pr.head.sha}; skipping stale DCO report`
+          );
+          return;
+        }
+        if (commits.length === 0) {
+          await reportDCO(context, {
+            sha,
+            ref,
+            timeStart,
+            conclusion: "neutral",
+            summary:
+              "The DCO check could not be evaluated because GitHub returned no commits for this pull request.\n\nPlease retry by re-running the check or pushing a new commit.",
+            statusState: "error",
+            statusDescription: "No pull request commits were returned.",
+          });
+          return;
+        }
+      }
 
-    const commits = compare.data.commits;
-    const dcoFailed = await getDCOStatus(
-      commits,
-      requireMembers(requireForMembers, context),
-      pr.html_url,
-      allowRemediationCommits
-    );
+      dcoFailed = await getDCOStatus(
+        commits,
+        requireMembers(requireForMembers, context),
+        pr.html_url,
+        allowRemediationCommits
+      );
+    } catch (error) {
+      context.log.error(error, "failed to evaluate DCO check");
+      await reportDCO(context, {
+        sha,
+        ref,
+        timeStart,
+        conclusion: "failure",
+        summary: evaluationErrorSummary(error),
+        statusDescription: "DCO check could not be evaluated.",
+      });
+      return;
+    }
 
     if (!dcoFailed.length) {
-      await context.octokit.rest.checks
-        .create(
-          context.repo({
-            name: "DCO",
-            head_branch: ref,
-            head_sha: sha,
-            status: "completed",
-            started_at: timeStart,
-            conclusion: "success",
-            completed_at: new Date(),
-            output: {
-              title: "DCO",
-              summary: "All commits are signed off!",
-            },
-          })
-        )
-        .catch(function checkFails(error) {
-          /* istanbul ignore next - unexpected error */
-          if (error.status !== 403) throw error;
-
-          context.log.info("resource not accessible, creating status instead");
-          // create status
-          const params = {
-            sha,
-            context: "DCO",
-            state: "success",
-            description: "All commits are signed off!",
-            target_url: "https://github.com/probot/dco#how-it-works",
-          };
-          return context.octokit.rest.repos.createCommitStatus(
-            context.repo(params)
-          );
-        });
+      await reportDCO(context, {
+        sha,
+        ref,
+        timeStart,
+        conclusion: "success",
+        summary: "All commits are signed off!",
+        statusState: "success",
+        statusDescription: "All commits are signed off!",
+      });
     } else {
       let summary = [];
       dcoFailed.forEach(function (commit) {
@@ -102,51 +121,90 @@ module.exports = (app) => {
         handleCommits(pr, commits.length, dcoFailed, allowRemediationCommits) +
         `\n\n### Summary\n\n${summary}`;
 
-      await context.octokit.rest.checks
-        .create(
-          context.repo({
-            name: "DCO",
-            head_branch: ref,
-            head_sha: sha,
-            status: "completed",
-            started_at: timeStart,
-            conclusion: "action_required",
-            completed_at: new Date(),
-            output: {
-              title: "DCO",
-              summary,
-            },
-            actions: [
-              {
-                label: "Set DCO to pass",
-                description: "would set status to passing",
-                identifier: "override",
-              },
-            ],
-          })
-        )
-        .catch(function checkFails(error) {
-          /* istanbul ignore next - unexpected error */
-          if (error.status !== 403) throw error;
+      await reportDCO(context, {
+        sha,
+        ref,
+        timeStart,
+        conclusion: "action_required",
+        summary,
+        statusDescription: dcoFailed[dcoFailed.length - 1].message.substring(
+          0,
+          140
+        ),
+        actions: [
+          {
+            label: "Set DCO to pass",
+            description: "would set status to passing",
+            identifier: "override",
+          },
+        ],
+      });
+    }
+  }
 
-          context.log.info("resource not accessible, creating status instead");
-          // create status
-          const description = dcoFailed[dcoFailed.length - 1].message.substring(
-            0,
-            140
-          );
-          const params = {
+  async function reportDCO(
+    context,
+    {
+      sha,
+      ref,
+      timeStart,
+      conclusion,
+      summary,
+      statusState = "failure",
+      statusDescription,
+      actions,
+    }
+  ) {
+    const params = {
+      name: "DCO",
+      head_branch: ref,
+      head_sha: sha,
+      status: "completed",
+      started_at: timeStart,
+      conclusion,
+      completed_at: new Date(),
+      output: {
+        title: "DCO",
+        summary,
+      },
+    };
+    if (actions) params.actions = actions;
+
+    try {
+      await context.octokit.rest.checks.create(context.repo(params));
+    } catch (error) {
+      if (error.status !== 403) {
+        context.log.error(error, "failed to create DCO check");
+        throw error;
+      }
+
+      context.log.info("resource not accessible, creating status instead");
+      try {
+        await context.octokit.rest.repos.createCommitStatus(
+          context.repo({
             sha,
             context: "DCO",
-            state: "failure",
-            description,
+            state: statusState,
+            description: statusDescription,
             target_url: "https://github.com/probot/dco#how-it-works",
-          };
-          return context.octokit.rest.repos.createCommitStatus(
-            context.repo(params)
-          );
-        });
+          })
+        );
+      } catch (statusError) {
+        context.log.error(statusError, "failed to create DCO status");
+        throw statusError;
+      }
     }
+  }
+
+  function evaluationErrorSummary(error) {
+    const requestId =
+      error.response?.headers?.["x-github-request-id"] || "unavailable";
+    return `The DCO check could not be evaluated because an error occurred while gathering or evaluating commits.
+
+HTTP status: ${error.status || "unknown"}
+GitHub request ID: ${requestId}
+
+Please retry by re-running the check or pushing a new commit.`;
   }
 
   app.on("merge_group.checks_requested", async (context) => {

--- a/test/fixtures/check_run.rerequested.json
+++ b/test/fixtures/check_run.rerequested.json
@@ -1,0 +1,164 @@
+{
+  "action": "rerequested",
+  "check_run": {
+    "id": 4,
+    "node_id": "MDg6Q2hlY2tSdW40",
+    "head_sha": "e76ed6025cec8879c75454a6efd6081d46de4c94",
+    "external_id": "",
+    "url": "https://api.github.com/repos/robotland/test/check-runs/4",
+    "html_url": "https://github.com/robotland/test/runs/4",
+    "details_url": "https://github.com/probot/dco#how-it-works",
+    "status": "completed",
+    "conclusion": "failure",
+    "started_at": "2017-09-22T23:21:03Z",
+    "completed_at": "2017-09-22T23:21:04Z",
+    "output": {
+      "title": "DCO",
+      "summary": "The sign-off is missing.",
+      "text": "",
+      "annotations_count": 0,
+      "annotations_url": "https://api.github.com/repos/robotland/test/check-runs/4/annotations"
+    },
+    "name": "DCO",
+    "check_suite": {
+      "id": 5,
+      "node_id": "MDEwOkNoZWNrU3VpdGU1",
+      "head_branch": "dco-test",
+      "head_sha": "e76ed6025cec8879c75454a6efd6081d46de4c94",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2017-09-22T23:21:03Z",
+      "updated_at": "2017-09-22T23:21:04Z",
+      "url": "https://api.github.com/repos/robotland/test/check-suites/5",
+      "before": "607c64cd8e37eb2db939f99a17bee5c7d1a90a31",
+      "after": "e76ed6025cec8879c75454a6efd6081d46de4c94",
+      "app": {
+        "id": 1,
+        "slug": "dco",
+        "node_id": "MDM6QXBwMQ==",
+        "owner": {
+          "login": "dcoapp",
+          "id": 1,
+          "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+          "url": "https://api.github.com/orgs/dcoapp",
+          "html_url": "https://github.com/dcoapp",
+          "type": "Organization",
+          "site_admin": false
+        },
+        "name": "DCO",
+        "description": "DCO GitHub App",
+        "external_url": "https://github.com/probot/dco",
+        "html_url": "https://github.com/apps/dco"
+      },
+      "pull_requests": [
+        {
+          "url": "https://api.github.com/repos/robotland/test/pulls/113",
+          "id": 142686911,
+          "number": 113,
+          "head": {
+            "ref": "dco-test",
+            "sha": "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            "repo": {
+              "id": 68474533,
+              "url": "https://api.github.com/repos/robotland/test",
+              "name": "test"
+            }
+          },
+          "base": {
+            "ref": "master",
+            "sha": "607c64cd8e37eb2db939f99a17bee5c7d1a90a31",
+            "repo": {
+              "id": 68474533,
+              "url": "https://api.github.com/repos/robotland/test",
+              "name": "test"
+            }
+          }
+        }
+      ]
+    },
+    "app": {
+      "id": 1,
+      "slug": "dco",
+      "node_id": "MDM6QXBwMQ==",
+      "owner": {
+        "login": "dcoapp",
+        "id": 1,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+        "url": "https://api.github.com/orgs/dcoapp",
+        "html_url": "https://github.com/dcoapp",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "name": "DCO",
+      "description": "DCO GitHub App",
+      "external_url": "https://github.com/probot/dco",
+      "html_url": "https://github.com/apps/dco"
+    },
+    "pull_requests": [
+      {
+        "url": "https://api.github.com/repos/robotland/test/pulls/113",
+        "id": 142686911,
+        "number": 113,
+        "head": {
+          "ref": "dco-test",
+          "sha": "e76ed6025cec8879c75454a6efd6081d46de4c94",
+          "repo": {
+            "id": 68474533,
+            "url": "https://api.github.com/repos/robotland/test",
+            "name": "test"
+          }
+        },
+        "base": {
+          "ref": "master",
+          "sha": "607c64cd8e37eb2db939f99a17bee5c7d1a90a31",
+          "repo": {
+            "id": 68474533,
+            "url": "https://api.github.com/repos/robotland/test",
+            "name": "test"
+          }
+        }
+      }
+    ]
+  },
+  "repository": {
+    "id": 68474533,
+    "name": "test",
+    "full_name": "robotland/test",
+    "owner": {
+      "login": "robotland",
+      "id": 11724939,
+      "node_id": "MDEyOk9yZ2FuaXphdGlvbjExNzI0OTM5",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/11724939?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/robotland",
+      "html_url": "https://github.com/robotland",
+      "type": "Organization",
+      "site_admin": false
+    },
+    "private": false,
+    "html_url": "https://github.com/robotland/test",
+    "description": "a trainable robot that responds to activity on GitHub",
+    "fork": false,
+    "url": "https://api.github.com/repos/robotland/test",
+    "default_branch": "master"
+  },
+  "organization": {
+    "login": "robotland",
+    "id": 11724939,
+    "url": "https://api.github.com/orgs/robotland"
+  },
+  "sender": {
+    "login": "bkeepers",
+    "id": 173,
+    "node_id": "MDQ6VXNlcjE3Mw==",
+    "avatar_url": "https://avatars0.githubusercontent.com/u/173?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/bkeepers",
+    "html_url": "https://github.com/bkeepers",
+    "type": "User",
+    "site_admin": true
+  },
+  "installation": {
+    "id": 13055
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,6 +12,11 @@ const pullRequestReviewCommentPayload = require("./fixtures/pull_request_review_
 const mergeGroupPayload = require("./fixtures/merge_group.checks_requested");
 const compare = require("./fixtures/compare");
 const compareSuccess = require("./fixtures/compare-success");
+const compareSuccessCommits = compareSuccess.commits.map((commit, index) =>
+  index === compareSuccess.commits.length - 1
+    ? { ...commit, sha: payloadSuccess.pull_request.head.sha }
+    : commit
+);
 
 nock.disableNetConnect();
 
@@ -41,10 +46,9 @@ describe("dco", () => {
         .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
         .reply(404)
 
-        .get(
-          "/repos/robotland/test/compare/607c64cd8e37eb2db939f99a17bee5c7d1a90a31...e76ed6025cec8879c75454a6efd6081d46de4c94"
-        )
-        .reply(200, compare)
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, compare.commits)
 
         .post("/repos/robotland/test/check-runs", (body) => {
           body.started_at = "2018-07-14T18:18:54.156Z";
@@ -67,10 +71,9 @@ describe("dco", () => {
         .get("/repos/octocat/.github/contents/.github%2Fdco.yml")
         .reply(404)
 
-        .get(
-          "/repos/octocat/Hello-World/compare/a10867b14bb761a232cd80139fbd4c0d33264240...34c5c7793cb3b279e22454cb6750c80560547b3a"
-        )
-        .reply(200, compareSuccess)
+        .get("/repos/octocat/Hello-World/pulls/1/commits")
+        .query({ per_page: "100" })
+        .reply(200, compareSuccessCommits)
 
         .post("/repos/octocat/Hello-World/check-runs", (body) => {
           body.started_at = "2018-07-14T18:18:54.156Z";
@@ -93,10 +96,9 @@ describe("dco", () => {
         .get("/repos/octocat/.github/contents/.github%2Fdco.yml")
         .reply(404)
 
-        .get(
-          "/repos/octocat/Hello-World/compare/a10867b14bb761a232cd80139fbd4c0d33264240...34c5c7793cb3b279e22454cb6750c80560547b3a"
-        )
-        .reply(200, compareSuccess)
+        .get("/repos/octocat/Hello-World/pulls/1/commits")
+        .query({ per_page: "100" })
+        .reply(200, compareSuccessCommits)
 
         .post("/repos/octocat/Hello-World/check-runs")
         .reply(403)
@@ -116,6 +118,300 @@ describe("dco", () => {
       expect(mock.activeMocks()).toStrictEqual([]);
     });
 
+    test("creates a failing check when commits cannot be listed", async () => {
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(
+          422,
+          {
+            message:
+              "Server Error: Sorry, this diff is taking too long to generate.",
+            errors: [
+              {
+                resource: "Comparison",
+                field: "diff",
+                code: "not_available",
+              },
+            ],
+          },
+          {
+            "x-github-request-id": "ABC1:DEF2:123456:789ABC",
+          }
+        )
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "failure",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain(
+            "The DCO check could not be evaluated"
+          );
+          expect(body.output.summary).toContain("HTTP status: 422");
+          expect(body.output.summary).toContain(
+            "GitHub request ID: ABC1:DEF2:123456:789ABC"
+          );
+          expect(body.output.summary).not.toContain("Server Error");
+          expect(body.output.summary).toContain("re-running the check");
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("creates a failing check when config cannot be fetched", async () => {
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(422, { message: "Invalid request" })
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "failure",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain("HTTP status: 422");
+          expect(body.output.summary).toContain(
+            "GitHub request ID: unavailable"
+          );
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("evaluates pull requests with more than 250 commits", async () => {
+      const commits = [
+        ...Array.from({ length: 249 }, (_, index) => ({
+          ...compareSuccess.commits[0],
+          sha: String(index).padStart(40, "0"),
+        })),
+        {
+          ...compare.commits[0],
+          sha: "9999999999999999999999999999999999999999",
+        },
+      ];
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, commits)
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "action_required",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain("The sign-off is missing.");
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("creates a neutral check when no commits are returned", async () => {
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, [])
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "neutral",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain("returned no commits");
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("evaluates commits from paginated pull request commits", async () => {
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, compareSuccess.commits, {
+          link: '<https://api.github.com/repos/robotland/test/pulls/113/commits?per_page=100&page=2>; rel="next"',
+        })
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100", page: "2" })
+        .reply(200, compare.commits)
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "action_required",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain("The sign-off is missing.");
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("creates a failing check when commit data cannot be evaluated", async () => {
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, [{ sha: "e76ed6025cec8879c75454a6efd6081d46de4c94" }])
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "failure",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain("HTTP status: unknown");
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("rethrows when the failure check cannot be created", async () => {
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(422, {
+          message:
+            "Server Error: Sorry, this diff is taking too long to generate.",
+        })
+
+        .post("/repos/robotland/test/check-runs")
+        .reply(404);
+
+      await expect(
+        probot.receive({ name: "pull_request", payload })
+      ).rejects.toThrow();
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("rethrows when the failure status cannot be created", async () => {
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(422, {
+          message:
+            "Server Error: Sorry, this diff is taking too long to generate.",
+        })
+
+        .post("/repos/robotland/test/check-runs")
+        .reply(403)
+
+        .post(
+          "/repos/robotland/test/statuses/e76ed6025cec8879c75454a6efd6081d46de4c94"
+        )
+        .reply(403);
+
+      await expect(
+        probot.receive({ name: "pull_request", payload })
+      ).rejects.toThrow();
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
     test("creates a error status if app has no access to checks", async () => {
       const mock = nock("https://api.github.com")
         .get("/repos/robotland/test/contents/.github%2Fdco.yml")
@@ -123,10 +419,9 @@ describe("dco", () => {
         .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
         .reply(404)
 
-        .get(
-          "/repos/robotland/test/compare/607c64cd8e37eb2db939f99a17bee5c7d1a90a31...e76ed6025cec8879c75454a6efd6081d46de4c94"
-        )
-        .reply(200, compare)
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, compare.commits)
 
         .post("/repos/robotland/test/check-runs")
         .reply(403)
@@ -159,10 +454,9 @@ describe("dco", () => {
     members: false`
             )
 
-            .get(
-              "/repos/robotland/test/compare/607c64cd8e37eb2db939f99a17bee5c7d1a90a31...e76ed6025cec8879c75454a6efd6081d46de4c94"
-            )
-            .reply(200, compare)
+            .get("/repos/robotland/test/pulls/113/commits")
+            .query({ per_page: "100" })
+            .reply(200, compare.commits)
 
             .get("/orgs/robotland/members/bkeepers")
             .reply(204)
@@ -191,17 +485,16 @@ describe("dco", () => {
     members: false`
             )
 
-            .get(
-              "/repos/robotland/test/compare/607c64cd8e37eb2db939f99a17bee5c7d1a90a31...e76ed6025cec8879c75454a6efd6081d46de4c94"
-            )
+            .get("/repos/robotland/test/pulls/113/commits")
+            .query({ per_page: "100" })
             // override verification status to true from fixtures, without mutating the fixtures
-            .reply(200, {
-              ...compare,
-              commits: compare.commits.map((commit) => ({
+            .reply(
+              200,
+              compare.commits.map((commit) => ({
                 ...commit,
                 commit: { ...commit.commit, verification: { verified: true } },
-              })),
-            })
+              }))
+            )
 
             .get("/orgs/robotland/members/bkeepers")
             .reply(204)
@@ -230,10 +523,9 @@ describe("dco", () => {
     members: false`
             )
 
-            .get(
-              "/repos/robotland/test/compare/607c64cd8e37eb2db939f99a17bee5c7d1a90a31...e76ed6025cec8879c75454a6efd6081d46de4c94"
-            )
-            .reply(200, compare)
+            .get("/repos/robotland/test/pulls/113/commits")
+            .query({ per_page: "100" })
+            .reply(200, compare.commits)
 
             .get("/orgs/robotland/members/bkeepers")
             .reply(404)
@@ -262,14 +554,10 @@ describe("dco", () => {
     members: false`
             )
 
-            .get(
-              "/repos/robotland/test/compare/607c64cd8e37eb2db939f99a17bee5c7d1a90a31...e76ed6025cec8879c75454a6efd6081d46de4c94"
-            )
+            .get("/repos/robotland/test/pulls/113/commits")
+            .query({ per_page: "100" })
             // duplicate commit without mutating the fixtures
-            .reply(200, {
-              ...compare,
-              commits: [compare.commits[0], compare.commits[0]],
-            })
+            .reply(200, [compare.commits[0], compare.commits[0]])
 
             .get("/orgs/robotland/members/bkeepers")
             .reply(204)
@@ -298,10 +586,9 @@ describe("dco", () => {
     members: false`
             )
 
-            .get(
-              "/repos/robotland/test/compare/607c64cd8e37eb2db939f99a17bee5c7d1a90a31...e76ed6025cec8879c75454a6efd6081d46de4c94"
-            )
-            .reply(200, compare)
+            .get("/repos/robotland/test/pulls/113/commits")
+            .query({ per_page: "100" })
+            .reply(200, compare.commits)
 
             .post("/repos/robotland/test/check-runs", (body) => {
               body.started_at = "2018-07-14T18:18:54.156Z";
@@ -331,10 +618,9 @@ describe("dco", () => {
     members: false`
             )
 
-            .get(
-              "/repos/bkeepers/test/compare/607c64cd8e37eb2db939f99a17bee5c7d1a90a31...e76ed6025cec8879c75454a6efd6081d46de4c94"
-            )
-            .reply(200, compare)
+            .get("/repos/bkeepers/test/pulls/113/commits")
+            .query({ per_page: "100" })
+            .reply(200, compare.commits)
 
             .post("/repos/bkeepers/test/check-runs", (body) => {
               body.started_at = "2018-07-14T18:18:54.156Z";
@@ -376,10 +662,9 @@ allowRemediationCommits:
   individual: true`
             )
 
-            .get(
-              "/repos/robotland/test/compare/607c64cd8e37eb2db939f99a17bee5c7d1a90a31...e76ed6025cec8879c75454a6efd6081d46de4c94"
-            )
-            .reply(200, compare)
+            .get("/repos/robotland/test/pulls/113/commits")
+            .query({ per_page: "100" })
+            .reply(200, compare.commits)
 
             .post("/repos/robotland/test/check-runs", (body) => {
               body.started_at = "2018-07-14T18:18:54.156Z";
@@ -408,10 +693,9 @@ allowRemediationCommits:
   thirdParty: true`
           )
 
-          .get(
-            "/repos/robotland/test/compare/607c64cd8e37eb2db939f99a17bee5c7d1a90a31...e76ed6025cec8879c75454a6efd6081d46de4c94"
-          )
-          .reply(200, compare)
+          .get("/repos/robotland/test/pulls/113/commits")
+          .query({ per_page: "100" })
+          .reply(200, compare.commits)
 
           .post("/repos/robotland/test/check-runs", (body) => {
             body.started_at = "2018-07-14T18:18:54.156Z";
@@ -437,32 +721,28 @@ allowRemediationCommits:
   thirdParty: true`
           )
 
-          .get(
-            "/repos/robotland/test/compare/607c64cd8e37eb2db939f99a17bee5c7d1a90a31...e76ed6025cec8879c75454a6efd6081d46de4c94"
-          )
+          .get("/repos/robotland/test/pulls/113/commits")
+          .query({ per_page: "100" })
           // add 2nd commit without mutating the fixtures
-          .reply(200, {
-            ...compare,
-            commits: [
-              compare.commits[0],
-              {
-                sha: "<other sha>",
-                commit: {
-                  author: {
-                    name: "Not Brandon Keepers",
-                    email: "not-bkeepers@github.com",
-                    date: "2017-09-22T23:20:56Z",
-                  },
-                  committer: {
-                    name: "Monalisa Octocat",
-                    email: "support@github.com",
-                    date: "2021-11-09T23:01:26.210Z",
-                  },
-                  message: "Other update README.md",
+          .reply(200, [
+            {
+              sha: "<other sha>",
+              commit: {
+                author: {
+                  name: "Not Brandon Keepers",
+                  email: "not-bkeepers@github.com",
+                  date: "2017-09-22T23:20:56Z",
                 },
+                committer: {
+                  name: "Monalisa Octocat",
+                  email: "support@github.com",
+                  date: "2021-11-09T23:01:26.210Z",
+                },
+                message: "Other update README.md",
               },
-            ],
-          })
+            },
+            compare.commits[0],
+          ])
 
           .post("/repos/robotland/test/check-runs", (body) => {
             body.started_at = "2018-07-14T18:18:54.156Z";
@@ -488,14 +768,10 @@ allowRemediationCommits:
   thirdParty: true`
           )
 
-          .get(
-            "/repos/robotland/test/compare/607c64cd8e37eb2db939f99a17bee5c7d1a90a31...e76ed6025cec8879c75454a6efd6081d46de4c94"
-          )
+          .get("/repos/robotland/test/pulls/113/commits")
+          .query({ per_page: "100" })
           // add 2nd commit without mutating the fixtures
-          .reply(200, {
-            ...compare,
-            commits: [compare.commits[0], compare.commits[0]],
-          })
+          .reply(200, [compare.commits[0], compare.commits[0]])
 
           .post("/repos/robotland/test/check-runs", (body) => {
             body.started_at = "2018-07-14T18:18:54.156Z";
@@ -587,10 +863,9 @@ allowRemediationCommits:
         .get("/repos/octocat/.github/contents/.github%2Fdco.yml")
         .reply(404)
 
-        .get(
-          "/repos/octocat/Hello-World/compare/a10867b14bb761a232cd80139fbd4c0d33264240...34c5c7793cb3b279e22454cb6750c80560547b3a"
-        )
-        .reply(200, compareSuccess)
+        .get("/repos/octocat/Hello-World/pulls/1/commits")
+        .query({ per_page: "100" })
+        .reply(200, compareSuccessCommits)
 
         .post("/repos/octocat/Hello-World/check-runs", (body) => {
           body.started_at = "2018-07-14T18:18:54.156Z";
@@ -656,10 +931,9 @@ allowRemediationCommits:
         .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
         .reply(404)
 
-        .get(
-          "/repos/robotland/test/compare/607c64cd8e37eb2db939f99a17bee5c7d1a90a31...e76ed6025cec8879c75454a6efd6081d46de4c94"
-        )
-        .reply(200, compare)
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, compare.commits)
 
         .post("/repos/robotland/test/check-runs", (body) => {
           body.started_at = "2018-07-14T18:18:54.156Z";
@@ -695,10 +969,9 @@ allowRemediationCommits:
     members: false`
         )
 
-        .get(
-          "/repos/robotland/test/compare/607c64cd8e37eb2db939f99a17bee5c7d1a90a31...e76ed6025cec8879c75454a6efd6081d46de4c94"
-        )
-        .reply(200, compare)
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, compare.commits)
 
         .get("/orgs/robotland/members/bkeepers")
         .reply(204)
@@ -827,6 +1100,62 @@ allowRemediationCommits:
           }
         )
         .reply(201);
+
+      await probot.receive({ name: "merge_group", payload: mergeGroupPayload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("creates a failing check when compare commits fails", async () => {
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/pulls/113")
+        .reply(200, payload.pull_request)
+
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get(
+          "/repos/robotland/test/compare/607c64cd8e37eb2db939f99a17bee5c7d1a90a31...abc123def456abc123def456abc123def456abc1"
+        )
+        .reply(422, {
+          message:
+            "Server Error: Sorry, this diff is taking too long to generate.",
+          errors: [
+            {
+              resource: "Comparison",
+              field: "diff",
+              code: "not_available",
+            },
+          ],
+        })
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "failure",
+            head_branch:
+              "gh-readonly-queue/master/pr-113-e76ed6025cec8879c75454a6efd6081d46de4c94",
+            head_sha: "abc123def456abc123def456abc123def456abc1",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain(
+            "The DCO check could not be evaluated"
+          );
+          expect(body.output.summary).toContain("HTTP status: 422");
+          expect(body.output.summary).toContain(
+            "GitHub request ID: unavailable"
+          );
+          expect(body.output.summary).not.toContain("Server Error");
+          return true;
+        })
+        .reply(200);
 
       await probot.receive({ name: "merge_group", payload: mergeGroupPayload });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,6 +7,7 @@ const dco = require("..");
 
 const payload = require("./fixtures/pull_request.opened");
 const payloadSuccess = require("./fixtures/pull_request.opened-success");
+const checkRunRerequestedPayload = require("./fixtures/check_run.rerequested");
 const pullRequestReviewPayload = require("./fixtures/pull_request_review.submitted");
 const pullRequestReviewCommentPayload = require("./fixtures/pull_request_review_comment.created");
 const mergeGroupPayload = require("./fixtures/merge_group.checks_requested");
@@ -207,7 +208,7 @@ describe("dco", () => {
       expect(mock.activeMocks()).toStrictEqual([]);
     });
 
-    test("evaluates pull requests with more than 250 commits", async () => {
+    test("evaluates all 250 returned pull request commits", async () => {
       const commits = [
         ...Array.from({ length: 249 }, (_, index) => ({
           ...compareSuccess.commits[0],
@@ -785,6 +786,148 @@ allowRemediationCommits:
 
         expect(mock.activeMocks()).toStrictEqual([]);
       });
+    });
+  });
+
+  describe("check_run.rerequested event", () => {
+    test("creates a failing check for a rerequested DCO check run", async () => {
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/pulls/113")
+        .reply(200, payload.pull_request)
+
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, compare.commits)
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "action_required",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain("The sign-off is missing.");
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({
+        name: "check_run",
+        payload: checkRunRerequestedPayload,
+      });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("creates a neutral check when the commit was superseded", async () => {
+      const supersededPr = structuredClone(payload.pull_request);
+      supersededPr.head.sha = "0000000000000000000000000000000000000000";
+
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/pulls/113")
+        .reply(200, supersededPr)
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "neutral",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain("has been superseded");
+          expect(body.output.summary).toContain(supersededPr.head.sha);
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({
+        name: "check_run",
+        payload: checkRunRerequestedPayload,
+      });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("creates a diagnostic check when no pull requests are associated", async () => {
+      const payload = structuredClone(checkRunRerequestedPayload);
+      payload.check_run.pull_requests = [];
+      payload.check_run.check_suite.pull_requests = [];
+      payload.check_run.check_suite.head_branch = null;
+
+      const mock = nock("https://api.github.com")
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "failure",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body).not.toHaveProperty("head_branch");
+          expect(body.output.summary).toContain(
+            "not associated with a pull request"
+          );
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "check_run", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("creates a diagnostic check when pull request lookup fails", async () => {
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/pulls/113")
+        .reply(404)
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "failure",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain(
+            "pull request #113 could not be fetched"
+          );
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({
+        name: "check_run",
+        payload: checkRunRerequestedPayload,
+      });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
     });
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1305,35 +1305,88 @@ allowRemediationCommits:
       expect(mock.activeMocks()).toStrictEqual([]);
     });
 
-    test("skips check when PR lookup returns 404", async () => {
+    test("creates a diagnostic check when PR lookup returns 404", async () => {
       const mock = nock("https://api.github.com")
         .get("/repos/robotland/test/pulls/113")
-        .reply(404);
+        .reply(404)
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "failure",
+            head_branch:
+              "gh-readonly-queue/master/pr-113-e76ed6025cec8879c75454a6efd6081d46de4c94",
+            head_sha: "abc123def456abc123def456abc123def456abc1",
+            name: "DCO",
+            status: "completed",
+          });
+          expect(body.output.summary).toContain(
+            "pull request #113 was not found"
+          );
+          return true;
+        })
+        .reply(200);
 
       await probot.receive({ name: "merge_group", payload: mergeGroupPayload });
 
       expect(mock.activeMocks()).toStrictEqual([]);
     });
 
-    test("skips check when PR lookup returns 403", async () => {
+    test("creates a diagnostic check when PR lookup returns 403", async () => {
       const mock = nock("https://api.github.com")
         .get("/repos/robotland/test/pulls/113")
-        .reply(403);
+        .reply(403)
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "failure",
+            head_branch:
+              "gh-readonly-queue/master/pr-113-e76ed6025cec8879c75454a6efd6081d46de4c94",
+            head_sha: "abc123def456abc123def456abc123def456abc1",
+            name: "DCO",
+            status: "completed",
+          });
+          expect(body.output.summary).toContain(
+            "pull request #113 could not be accessed"
+          );
+          return true;
+        })
+        .reply(200);
 
       await probot.receive({ name: "merge_group", payload: mergeGroupPayload });
 
       expect(mock.activeMocks()).toStrictEqual([]);
     });
 
-    test("rethrows non-404/403 errors from PR lookup", async () => {
-      // Use 422 (not retried by octokit) to verify non-404/403 errors propagate
-      nock("https://api.github.com")
+    test("creates a diagnostic check when PR lookup returns another error", async () => {
+      const mock = nock("https://api.github.com")
         .get("/repos/robotland/test/pulls/113")
-        .reply(422);
+        .reply(422)
 
-      await expect(
-        probot.receive({ name: "merge_group", payload: mergeGroupPayload })
-      ).rejects.toThrow();
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "failure",
+            head_branch:
+              "gh-readonly-queue/master/pr-113-e76ed6025cec8879c75454a6efd6081d46de4c94",
+            head_sha: "abc123def456abc123def456abc123def456abc1",
+            name: "DCO",
+            status: "completed",
+          });
+          expect(body.output.summary).toContain(
+            "pull request #113 could not be fetched"
+          );
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "merge_group", payload: mergeGroupPayload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
     });
 
     test("creates a passing check when head_ref has no refs/heads/ prefix", async () => {
@@ -1383,7 +1436,7 @@ allowRemediationCommits:
       expect(mock.activeMocks()).toStrictEqual([]);
     });
 
-    test("ignores merge_group with unrecognized head_ref format", async () => {
+    test("creates a diagnostic check for unrecognized head_ref format", async () => {
       const unknownRefPayload = {
         ...mergeGroupPayload,
         merge_group: {
@@ -1392,7 +1445,23 @@ allowRemediationCommits:
         },
       };
 
-      const mock = nock("https://api.github.com");
+      const mock = nock("https://api.github.com")
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "failure",
+            head_branch: "some-feature-branch/pr-113-abc123",
+            head_sha: "abc123def456abc123def456abc123def456abc1",
+            name: "DCO",
+            status: "completed",
+          });
+          expect(body.output.summary).toContain(
+            "unrecognized format: some-feature-branch/pr-113-abc123"
+          );
+          return true;
+        })
+        .reply(200);
 
       await probot.receive({
         name: "merge_group",


### PR DESCRIPTION
## Summary

- Closes #302: compare API 422 failures left the required DCO check unreported forever. Commit gathering and configuration loading are now wrapped in a safety net that always publishes a result, and pull-request-driven checks use `pulls.listCommits` so no diff is generated.
- Closes #305: `check_run.rerequested` never worked because check-run payloads have no top-level `pull_request`. The handler now resolves the PR before checking, and re-runs against superseded commits publish an explicit neutral result.
- Refs #303: merge group setup failures now publish a diagnostic DCO check instead of returning silently.

Known limitations:

- Pull requests with more than 250 commits are still only partially evaluated; tracked separately in #308.
- `check_run.pull_requests[0]` disambiguation is tracked separately in #307.

## Testing

- `npm test`