### PR TITLE
Fix: Handle large PR commit lists

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,11 @@
 const getDCOStatus = require("./lib/dco.js");
 const requireMembers = require("./lib/requireMembers.js");
 
+// GitHub documents a 250-commit cap on the pull request commits REST endpoint.
+const PULL_REQUEST_COMMITS_REST_LIMIT = 250;
+const PULL_REQUEST_COMMITS_GRAPHQL_PAGE_SIZE = 100;
+const PULL_REQUEST_COMMITS_GRAPHQL_PAGE_MARGIN = 1;
+
 /**
  * @param {import('probot').Probot} app
  */
@@ -44,10 +49,7 @@ module.exports = (app) => {
         );
         commits = compare.data.commits;
       } else {
-        commits = await context.octokit.paginate(
-          context.octokit.rest.pulls.listCommits,
-          context.repo({ pull_number: pr.number, per_page: 100 })
-        );
+        commits = await listPullRequestCommits(context, pr);
         if (commits.length === 0) {
           await reportDCO(context, {
             sha,
@@ -128,6 +130,203 @@ module.exports = (app) => {
     }
   }
 
+  async function listPullRequestCommits(context, pr) {
+    const commits = await context.octokit.paginate(
+      context.octokit.rest.pulls.listCommits,
+      context.repo({ pull_number: pr.number, per_page: 100 })
+    );
+
+    if (commits.length !== PULL_REQUEST_COMMITS_REST_LIMIT) {
+      return commits;
+    }
+
+    return fetchCompletePullRequestCommits(context, pr);
+  }
+
+  async function fetchCompletePullRequestCommits(context, pr) {
+    try {
+      const commits = [];
+      const commitShas = new Set();
+      let cursor = null;
+      let hasNextPage = true;
+      let expectedCommitCount;
+      let maxPages;
+      let pageCount = 0;
+
+      while (hasNextPage) {
+        const response = await context.octokit.graphql(
+          `query PullRequestCommits(
+            $owner: String!
+            $repo: String!
+            $pullNumber: Int!
+            $cursor: String
+            $pageSize: Int!
+          ) {
+            repository(owner: $owner, name: $repo) {
+              pullRequest(number: $pullNumber) {
+                commits(first: $pageSize, after: $cursor) {
+                  totalCount
+                  nodes {
+                    commit {
+                      oid
+                      url
+                      message
+                      author {
+                        name
+                        email
+                        date
+                        user {
+                          login
+                          __typename
+                        }
+                      }
+                      committer {
+                        name
+                        email
+                        date
+                        user {
+                          login
+                          __typename
+                        }
+                      }
+                      signature {
+                        isValid
+                        state
+                        signature
+                        payload
+                      }
+                      parents(first: 100) {
+                        nodes {
+                          oid
+                          url
+                        }
+                      }
+                    }
+                  }
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
+                }
+              }
+            }
+          }`,
+          context.repo({
+            pullNumber: pr.number,
+            cursor,
+            pageSize: PULL_REQUEST_COMMITS_GRAPHQL_PAGE_SIZE,
+          })
+        );
+        const connection = response.repository.pullRequest.commits;
+        pageCount += 1;
+        if (connection.totalCount < PULL_REQUEST_COMMITS_REST_LIMIT) {
+          throw new Error(
+            `GraphQL reported only ${connection.totalCount} pull request commits.`
+          );
+        }
+        if (expectedCommitCount === undefined) {
+          expectedCommitCount = connection.totalCount;
+          maxPages =
+            Math.ceil(
+              expectedCommitCount / PULL_REQUEST_COMMITS_GRAPHQL_PAGE_SIZE
+            ) + PULL_REQUEST_COMMITS_GRAPHQL_PAGE_MARGIN;
+        } else if (connection.totalCount !== expectedCommitCount) {
+          throw new Error(
+            `GraphQL totalCount changed from ${expectedCommitCount} to ${connection.totalCount}.`
+          );
+        }
+
+        for (const node of connection.nodes) {
+          const commit = mapGraphQLCommit(node);
+          if (commitShas.has(commit.sha)) {
+            throw new Error(
+              `GraphQL returned duplicate pull request commit ${commit.sha}.`
+            );
+          }
+          commitShas.add(commit.sha);
+          commits.push(commit);
+        }
+
+        hasNextPage = connection.pageInfo.hasNextPage;
+        const previousCursor = cursor;
+        cursor = connection.pageInfo.endCursor;
+
+        if (hasNextPage && !cursor) {
+          throw new Error("GraphQL pagination ended without a cursor.");
+        }
+        if (hasNextPage && cursor === previousCursor) {
+          throw new Error("GraphQL pagination cursor did not advance.");
+        }
+        if (hasNextPage && pageCount >= maxPages) {
+          throw new Error("GraphQL commit pagination exceeded expected pages.");
+        }
+      }
+
+      if (commitShas.size !== expectedCommitCount) {
+        throw new Error(
+          `GraphQL returned ${commitShas.size} of ${expectedCommitCount} pull request commits.`
+        );
+      }
+
+      return commits;
+    } catch (error) {
+      error.incompleteCommitList = true;
+      throw error;
+    }
+  }
+
+  function mapGraphQLCommit(node) {
+    const commit = node.commit;
+    const signature = commit.signature || {
+      isValid: false,
+      state: "unsigned",
+      signature: null,
+      payload: null,
+    };
+
+    return {
+      sha: commit.oid,
+      html_url: commit.url,
+      author: mapGraphQLUser(commit.author.user),
+      committer: mapGraphQLUser(commit.committer.user),
+      parents: commit.parents.nodes.map((parent) => ({
+        sha: parent.oid,
+        html_url: parent.url,
+      })),
+      commit: {
+        author: {
+          name: commit.author.name,
+          email: commit.author.email,
+          date: commit.author.date,
+        },
+        committer: {
+          name: commit.committer.name,
+          email: commit.committer.email,
+          date: commit.committer.date,
+        },
+        message: commit.message,
+        verification: {
+          verified: signature.isValid,
+          reason: signature.state,
+          signature: signature.signature,
+          payload: signature.payload,
+          verified_at: null,
+        },
+      },
+    };
+  }
+
+  function mapGraphQLUser(user) {
+    if (!user) {
+      return null;
+    }
+
+    return {
+      login: user.login,
+      type: user.login.endsWith("[bot]") ? "Bot" : user.__typename,
+    };
+  }
+
   async function reportDCO(
     context,
     {
@@ -185,6 +384,17 @@ module.exports = (app) => {
   function evaluationErrorSummary(error) {
     const requestId =
       error.response?.headers?.["x-github-request-id"] || "unavailable";
+    if (error.incompleteCommitList) {
+      return `The DCO check could not be evaluated because the complete pull request commit list could not be retrieved.
+
+GitHub returned 250 commits from the REST API, so the app attempted to retrieve the full list through GraphQL before evaluating the pull request. That fallback did not complete, so the DCO verdict is unknown.
+
+HTTP status: ${error.status || "unknown"}
+GitHub request ID: ${requestId}
+
+Please retry by re-running the check or pushing a new commit.`;
+    }
+
     return `The DCO check could not be evaluated because an error occurred while gathering or evaluating commits.
 
 HTTP status: ${error.status || "unknown"}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -18,6 +18,91 @@ const compareSuccessCommits = compareSuccess.commits.map((commit, index) =>
     ? { ...commit, sha: payloadSuccess.pull_request.head.sha }
     : commit
 );
+const belowRestLimitGraphQLTotalCounts = [249, 0];
+
+function makeCommit(source, index) {
+  return {
+    ...source,
+    sha: index.toString(16).padStart(40, "0"),
+  };
+}
+
+function graphQLNode(restCommit, options = {}) {
+  const authorUser =
+    options.authorUser === undefined
+      ? {
+          login: restCommit.author.login,
+          __typename: restCommit.author.type,
+        }
+      : options.authorUser;
+  const committerUser =
+    options.committerUser === undefined
+      ? {
+          login: restCommit.committer.login,
+          __typename: restCommit.committer.type,
+        }
+      : options.committerUser;
+
+  return {
+    commit: {
+      oid: restCommit.sha,
+      url: restCommit.html_url,
+      message: restCommit.commit.message,
+      author: {
+        ...restCommit.commit.author,
+        user: authorUser,
+      },
+      committer: {
+        ...restCommit.commit.committer,
+        user: committerUser,
+      },
+      signature: options.signature || null,
+      parents: {
+        nodes: restCommit.parents.map((parent) => ({
+          oid: parent.sha,
+          url: parent.html_url,
+        })),
+      },
+    },
+  };
+}
+
+function graphQLCommits(commits, pageInfo, options = {}) {
+  return {
+    repository: {
+      pullRequest: {
+        commits: {
+          totalCount: options.totalCount ?? commits.length,
+          nodes: commits.map((commit, index) =>
+            graphQLNode(commit, options[index])
+          ),
+          pageInfo,
+        },
+      },
+    },
+  };
+}
+
+function expectIncompleteCommitListCheck(body) {
+  body.started_at = "2018-07-14T18:18:54.156Z";
+  body.completed_at = "2018-07-14T18:18:54.156Z";
+  expect(body).toMatchObject({
+    conclusion: "failure",
+    head_branch: "dco-test",
+    head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+    name: "DCO",
+    output: {
+      title: "DCO",
+    },
+    status: "completed",
+  });
+  expect(body.output.summary).toContain(
+    "complete pull request commit list could not be retrieved"
+  );
+  expect(body.output.summary).toContain("verdict is unknown");
+  expect(body.output.summary).not.toContain("All commits are signed");
+  return true;
+}
 
 nock.disableNetConnect();
 
@@ -208,17 +293,10 @@ describe("dco", () => {
       expect(mock.activeMocks()).toStrictEqual([]);
     });
 
-    test("evaluates all 250 returned pull request commits", async () => {
-      const commits = [
-        ...Array.from({ length: 249 }, (_, index) => ({
-          ...compareSuccess.commits[0],
-          sha: String(index).padStart(40, "0"),
-        })),
-        {
-          ...compare.commits[0],
-          sha: "9999999999999999999999999999999999999999",
-        },
-      ];
+    test("escalates exactly 250 REST commits to GraphQL", async () => {
+      const restCommits = Array.from({ length: 250 }, (_, index) =>
+        makeCommit(compareSuccess.commits[0], index)
+      );
       const mock = nock("https://api.github.com")
         .get("/repos/robotland/test/contents/.github%2Fdco.yml")
         .reply(404)
@@ -227,7 +305,85 @@ describe("dco", () => {
 
         .get("/repos/robotland/test/pulls/113/commits")
         .query({ per_page: "100" })
-        .reply(200, commits)
+        .reply(200, restCommits)
+
+        .post("/graphql", (body) => {
+          expect(body.variables).toMatchObject({
+            owner: "robotland",
+            repo: "test",
+            pullNumber: 113,
+            cursor: null,
+          });
+          return true;
+        })
+        .reply(200, {
+          data: graphQLCommits(
+            restCommits,
+            {
+              hasNextPage: false,
+              endCursor: null,
+            },
+            {
+              0: {
+                authorUser: null,
+                committerUser: null,
+                signature: {
+                  isValid: true,
+                  state: "VALID",
+                  signature: "signature",
+                  payload: "payload",
+                },
+              },
+            }
+          ),
+        })
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "success",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain("All commits are signed off!");
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("fails when only GraphQL sees a missing sign-off", async () => {
+      const restCommits = Array.from({ length: 250 }, (_, index) =>
+        makeCommit(compareSuccess.commits[0], index)
+      );
+      const failingCommit = makeCommit(compare.commits[0], 250);
+      const commits = [...restCommits, failingCommit];
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, restCommits)
+
+        .post("/graphql")
+        .reply(200, {
+          data: graphQLCommits(commits, {
+            hasNextPage: false,
+            endCursor: null,
+          }),
+        })
 
         .post("/repos/robotland/test/check-runs", (body) => {
           body.started_at = "2018-07-14T18:18:54.156Z";
@@ -243,6 +399,587 @@ describe("dco", () => {
             status: "completed",
           });
           expect(body.output.summary).toContain("The sign-off is missing.");
+          expect(body.output.summary).toContain(failingCommit.sha);
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("preserves bot author handling from GraphQL commits", async () => {
+      const restCommits = Array.from({ length: 250 }, (_, index) =>
+        makeCommit(compareSuccess.commits[0], index)
+      );
+      const botCommit = makeCommit(compare.commits[0], 250);
+      const commits = [...restCommits, botCommit];
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, restCommits)
+
+        .post("/graphql")
+        .reply(200, {
+          data: graphQLCommits(
+            commits,
+            {
+              hasNextPage: false,
+              endCursor: null,
+            },
+            {
+              250: {
+                authorUser: {
+                  login: "dependabot[bot]",
+                  __typename: "User",
+                },
+              },
+            }
+          ),
+        })
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "success",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain("All commits are signed off!");
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("paginates GraphQL commits after REST truncation", async () => {
+      const restCommits = Array.from({ length: 250 }, (_, index) =>
+        makeCommit(compareSuccess.commits[0], index)
+      );
+      const commits = Array.from({ length: 251 }, (_, index) =>
+        makeCommit(compareSuccess.commits[0], index)
+      );
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, restCommits)
+
+        .post("/graphql", (body) => {
+          expect(body.variables.cursor).toBeNull();
+          return true;
+        })
+        .reply(200, {
+          data: graphQLCommits(
+            commits.slice(0, 100),
+            {
+              hasNextPage: true,
+              endCursor: "cursor-100",
+            },
+            { totalCount: commits.length }
+          ),
+        })
+
+        .post("/graphql", (body) => {
+          expect(body.variables.cursor).toBe("cursor-100");
+          return true;
+        })
+        .reply(200, {
+          data: graphQLCommits(
+            commits.slice(100),
+            {
+              hasNextPage: false,
+              endCursor: null,
+            },
+            { totalCount: commits.length }
+          ),
+        })
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "success",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain("All commits are signed off!");
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("fails closed when GraphQL commit fetching fails", async () => {
+      const restCommits = Array.from({ length: 250 }, (_, index) =>
+        makeCommit(compareSuccess.commits[0], index)
+      );
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, restCommits)
+
+        .post("/graphql")
+        .reply(200, {
+          errors: [{ message: "GraphQL unavailable" }],
+        })
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "failure",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain(
+            "complete pull request commit list could not be retrieved"
+          );
+          expect(body.output.summary).toContain("verdict is unknown");
+          expect(body.output.summary).toContain("HTTP status:");
+          expect(body.output.summary).toContain(
+            "GitHub request ID: unavailable"
+          );
+          expect(body.output.summary).not.toContain("All commits are signed");
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("fails closed when GraphQL returns partial data with errors", async () => {
+      const restCommits = Array.from({ length: 250 }, (_, index) =>
+        makeCommit(compareSuccess.commits[0], index)
+      );
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, restCommits)
+
+        .post("/graphql")
+        .reply(200, {
+          data: graphQLCommits(restCommits, {
+            hasNextPage: false,
+            endCursor: null,
+          }),
+          errors: [{ message: "GraphQL returned partial data" }],
+        })
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          expectIncompleteCommitListCheck(body);
+          expect(body.output.summary).toContain("HTTP status:");
+          expect(body.output.summary).toContain(
+            "GitHub request ID: unavailable"
+          );
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("fails closed when GraphQL pagination is incomplete", async () => {
+      const restCommits = Array.from({ length: 250 }, (_, index) =>
+        makeCommit(compareSuccess.commits[0], index)
+      );
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, restCommits)
+
+        .post("/graphql")
+        .reply(200, {
+          data: graphQLCommits(
+            restCommits.slice(0, 100),
+            {
+              hasNextPage: true,
+              endCursor: null,
+            },
+            { totalCount: 250 }
+          ),
+        })
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "failure",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain(
+            "complete pull request commit list could not be retrieved"
+          );
+          expect(body.output.summary).toContain("verdict is unknown");
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("fails closed when GraphQL pagination exceeds expected pages", async () => {
+      const restCommits = Array.from({ length: 250 }, (_, index) =>
+        makeCommit(compareSuccess.commits[0], index)
+      );
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, restCommits)
+
+        .post("/graphql")
+        .reply(200, {
+          data: graphQLCommits(
+            [],
+            {
+              hasNextPage: true,
+              endCursor: "cursor-60",
+            },
+            { totalCount: 250 }
+          ),
+        })
+
+        .post("/graphql")
+        .reply(200, {
+          data: graphQLCommits(
+            [],
+            {
+              hasNextPage: true,
+              endCursor: "cursor-120",
+            },
+            { totalCount: 250 }
+          ),
+        })
+
+        .post("/graphql")
+        .reply(200, {
+          data: graphQLCommits(
+            [],
+            {
+              hasNextPage: true,
+              endCursor: "cursor-180",
+            },
+            { totalCount: 250 }
+          ),
+        })
+
+        .post("/graphql")
+        .reply(200, {
+          data: graphQLCommits(
+            [],
+            {
+              hasNextPage: true,
+              endCursor: "cursor-240",
+            },
+            { totalCount: 250 }
+          ),
+        })
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          expectIncompleteCommitListCheck(body);
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    }, 10_000);
+
+    for (const totalCount of belowRestLimitGraphQLTotalCounts) {
+      test(`fails closed when GraphQL totalCount is ${totalCount}`, async () => {
+        const restCommits = Array.from({ length: 250 }, (_, index) =>
+          makeCommit(compareSuccess.commits[0], index)
+        );
+        const graphQLCommitsPage = restCommits.slice(0, totalCount);
+        const mock = nock("https://api.github.com")
+          .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+          .reply(404)
+          .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+          .reply(404)
+
+          .get("/repos/robotland/test/pulls/113/commits")
+          .query({ per_page: "100" })
+          .reply(200, restCommits)
+
+          .post("/graphql")
+          .reply(200, {
+            data: graphQLCommits(
+              graphQLCommitsPage,
+              {
+                hasNextPage: false,
+                endCursor: null,
+              },
+              { totalCount }
+            ),
+          })
+
+          .post("/repos/robotland/test/check-runs", (body) => {
+            expectIncompleteCommitListCheck(body);
+            return true;
+          })
+          .reply(200);
+
+        await probot.receive({ name: "pull_request", payload });
+
+        expect(mock.activeMocks()).toStrictEqual([]);
+      });
+    }
+
+    test("fails closed when GraphQL totalCount changes between pages", async () => {
+      const restCommits = Array.from({ length: 250 }, (_, index) =>
+        makeCommit(compareSuccess.commits[0], index)
+      );
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, restCommits)
+
+        .post("/graphql")
+        .reply(200, {
+          data: graphQLCommits(
+            restCommits.slice(0, 100),
+            {
+              hasNextPage: true,
+              endCursor: "cursor-100",
+            },
+            { totalCount: 250 }
+          ),
+        })
+
+        .post("/graphql")
+        .reply(200, {
+          data: graphQLCommits(
+            restCommits.slice(100, 200),
+            {
+              hasNextPage: false,
+              endCursor: null,
+            },
+            { totalCount: 251 }
+          ),
+        })
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          expectIncompleteCommitListCheck(body);
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("fails closed when GraphQL returns too few commits", async () => {
+      const restCommits = Array.from({ length: 250 }, (_, index) =>
+        makeCommit(compareSuccess.commits[0], index)
+      );
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, restCommits)
+
+        .post("/graphql")
+        .reply(200, {
+          data: graphQLCommits(
+            restCommits.slice(0, 100),
+            {
+              hasNextPage: false,
+              endCursor: null,
+            },
+            { totalCount: 251 }
+          ),
+        })
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          body.started_at = "2018-07-14T18:18:54.156Z";
+          body.completed_at = "2018-07-14T18:18:54.156Z";
+          expect(body).toMatchObject({
+            conclusion: "failure",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            output: {
+              title: "DCO",
+            },
+            status: "completed",
+          });
+          expect(body.output.summary).toContain(
+            "complete pull request commit list could not be retrieved"
+          );
+          expect(body.output.summary).toContain("verdict is unknown");
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("fails closed when GraphQL cursor does not advance", async () => {
+      const restCommits = Array.from({ length: 250 }, (_, index) =>
+        makeCommit(compareSuccess.commits[0], index)
+      );
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, restCommits)
+
+        .post("/graphql")
+        .reply(200, {
+          data: graphQLCommits(
+            restCommits.slice(0, 100),
+            {
+              hasNextPage: true,
+              endCursor: "cursor-100",
+            },
+            { totalCount: 250 }
+          ),
+        })
+
+        .post("/graphql")
+        .reply(200, {
+          data: graphQLCommits(
+            restCommits.slice(100, 200),
+            {
+              hasNextPage: true,
+              endCursor: "cursor-100",
+            },
+            { totalCount: 250 }
+          ),
+        })
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          expectIncompleteCommitListCheck(body);
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({ name: "pull_request", payload });
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("fails closed when GraphQL returns duplicate commits", async () => {
+      const restCommits = Array.from({ length: 250 }, (_, index) =>
+        makeCommit(compareSuccess.commits[0], index)
+      );
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, restCommits)
+
+        .post("/graphql")
+        .reply(200, {
+          data: graphQLCommits(
+            restCommits.slice(0, 100),
+            {
+              hasNextPage: true,
+              endCursor: "cursor-100",
+            },
+            { totalCount: 250 }
+          ),
+        })
+
+        .post("/graphql")
+        .reply(200, {
+          data: graphQLCommits(
+            restCommits.slice(0, 100),
+            {
+              hasNextPage: false,
+              endCursor: null,
+            },
+            { totalCount: 250 }
+          ),
+        })
+
+        .post("/repos/robotland/test/check-runs", (body) => {
+          expectIncompleteCommitListCheck(body);
           return true;
         })
         .reply(200);


### PR DESCRIPTION
## Bug

GitHub caps the pull request commits endpoint at 250 commits, and pagination does not lift that cap. For pull requests with more than 250 commits, the app evaluated only the first 250 and reported a verdict as though the entire list had been seen. A commit missing its sign-off beyond position 250 was never examined, so the app could report a passing DCO check for a pull request that does not actually pass. That is a silent false pass on a compliance gate.

## Fix

REST `pulls.listCommits` remains the primary path. When it returns exactly 250 commits, which is the truncation signal, the app escalates to the paginated GraphQL `PullRequest.commits` connection, which has no 250 cap, and evaluates the complete list. GraphQL commits are mapped into the same shape `lib/dco.js` already consumes so downstream behavior is unchanged.

## Fail-closed guarantee

If a complete, self-consistent commit list cannot be obtained, the app never reports a pass. It rejects a GraphQL `totalCount` below 250, which would contradict what REST already proved, a `totalCount` that changes between pages, duplicate commit SHAs, a cursor that does not advance, pagination exceeding the expected page count, and any GraphQL error or partial response. Completeness is validated on the count of unique commit SHAs, not merely the array length.

No new permissions are required; GraphQL uses the existing `pull_requests: read` permission.

The `merge_group` / `compareCommits` path is deliberately unchanged in this PR.

Closes #308
