### PR TITLE
Fix: Remove dead status fallback

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -30,6 +30,10 @@ entries under **Repository permissions** and lists **Members** under
 
 <!-- markdownlint-enable MD013 -->
 
+The app publishes DCO results through the Checks API. The `statuses`
+permission is not requested, and self-hosted deployments should not expect the
+app to fall back to commit statuses when check creation fails.
+
 ## Required event subscriptions
 
 In GitHub's "Subscribe to events" list, use the display label shown in the

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = (app) => {
     let commits;
     let dcoFailed;
     let allowRemediationCommits;
+    let noPullRequestCommits = false;
     try {
       const config = await context.config("dco.yml", {
         require: {
@@ -50,27 +51,17 @@ module.exports = (app) => {
         commits = compare.data.commits;
       } else {
         commits = await listPullRequestCommits(context, pr);
-        if (commits.length === 0) {
-          await reportDCO(context, {
-            sha,
-            ref,
-            timeStart,
-            conclusion: "neutral",
-            summary:
-              "The DCO check could not be evaluated because GitHub returned no commits for this pull request.\n\nPlease retry by re-running the check or pushing a new commit.",
-            statusState: "error",
-            statusDescription: "No pull request commits were returned.",
-          });
-          return;
-        }
+        noPullRequestCommits = commits.length === 0;
       }
 
-      dcoFailed = await getDCOStatus(
-        commits,
-        requireMembers(requireForMembers, context),
-        pr.html_url,
-        allowRemediationCommits
-      );
+      if (!noPullRequestCommits) {
+        dcoFailed = await getDCOStatus(
+          commits,
+          requireMembers(requireForMembers, context),
+          pr.html_url,
+          allowRemediationCommits
+        );
+      }
     } catch (error) {
       context.log.error(error, "failed to evaluate DCO check");
       await reportDCO(context, {
@@ -79,7 +70,18 @@ module.exports = (app) => {
         timeStart,
         conclusion: "failure",
         summary: evaluationErrorSummary(error),
-        statusDescription: "DCO check could not be evaluated.",
+      });
+      return;
+    }
+
+    if (noPullRequestCommits) {
+      await reportDCO(context, {
+        sha,
+        ref,
+        timeStart,
+        conclusion: "neutral",
+        summary:
+          "The DCO check could not be evaluated because GitHub returned no commits for this pull request.\n\nPlease retry by re-running the check or pushing a new commit.",
       });
       return;
     }
@@ -91,8 +93,6 @@ module.exports = (app) => {
         timeStart,
         conclusion: "success",
         summary: "All commits are signed off!",
-        statusState: "success",
-        statusDescription: "All commits are signed off!",
       });
     } else {
       let summary = [];
@@ -115,10 +115,6 @@ module.exports = (app) => {
         timeStart,
         conclusion: "action_required",
         summary,
-        statusDescription: dcoFailed[dcoFailed.length - 1].message.substring(
-          0,
-          140
-        ),
         actions: [
           {
             label: "Set DCO to pass",
@@ -329,16 +325,7 @@ module.exports = (app) => {
 
   async function reportDCO(
     context,
-    {
-      sha,
-      ref,
-      timeStart,
-      conclusion,
-      summary,
-      statusState = "failure",
-      statusDescription,
-      actions,
-    }
+    { sha, ref, timeStart, conclusion, summary, actions }
   ) {
     const params = {
       name: "DCO",
@@ -358,26 +345,8 @@ module.exports = (app) => {
     try {
       await context.octokit.rest.checks.create(context.repo(params));
     } catch (error) {
-      if (error.status !== 403) {
-        context.log.error(error, "failed to create DCO check");
-        throw error;
-      }
-
-      context.log.info("resource not accessible, creating status instead");
-      try {
-        await context.octokit.rest.repos.createCommitStatus(
-          context.repo({
-            sha,
-            context: "DCO",
-            state: statusState,
-            description: statusDescription,
-            target_url: "https://github.com/probot/dco#how-it-works",
-          })
-        );
-      } catch (statusError) {
-        context.log.error(statusError, "failed to create DCO status");
-        throw statusError;
-      }
+      context.log.error(error, "failed to create DCO check");
+      throw error;
     }
   }
 
@@ -419,7 +388,6 @@ Please retry by re-running the check or pushing a new commit.`;
         summary: `The DCO check could not be evaluated because the merge group head ref has an unrecognized format: ${mergeGroup.head_ref}.
 
 A maintainer can retry the merge queue entry. If this keeps happening, please report the merge group payload to the DCO app maintainers.`,
-        statusDescription: "Unrecognized merge group head ref.",
       });
       return;
     }
@@ -446,7 +414,6 @@ A maintainer can retry the merge queue entry. If this keeps happening, please re
         summary: `The DCO check could not be evaluated because ${reason}.
 
 A maintainer can retry the merge queue entry after confirming the pull request still exists and the DCO app can access it.`,
-        statusDescription: `Could not fetch PR #${prNumber}.`,
       });
       return;
     }
@@ -476,7 +443,6 @@ A maintainer can retry the merge queue entry after confirming the pull request s
         conclusion: "failure",
         summary:
           "The DCO check could not be evaluated because this check run is not associated with a pull request.\n\nPlease retry by pushing a new commit or opening a pull request with this commit.",
-        statusDescription: "DCO check is not associated with a pull request.",
       });
       return;
     }
@@ -499,7 +465,6 @@ A maintainer can retry the merge queue entry after confirming the pull request s
         summary: `The DCO check could not be evaluated because pull request #${pullRequest.number} could not be fetched.
 
 Please retry by re-running the check or pushing a new commit.`,
-        statusDescription: `Could not fetch PR #${pullRequest.number}.`,
       });
       return;
     }
@@ -515,8 +480,6 @@ Please retry by re-running the check or pushing a new commit.`,
 Current pull request head: ${pr.head.sha}
 
 Please use the DCO check on the current pull request head, or push a new commit to trigger a fresh check.`,
-        statusState: "success",
-        statusDescription: "This commit has been superseded.",
       });
       return;
     }

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -16,15 +16,6 @@ Object {
 }
 `;
 
-exports[`dco merge_group event falls back to status API when check-runs returns 403 1`] = `
-Object {
-  "context": "DCO",
-  "description": "The sign-off is missing.",
-  "state": "failure",
-  "target_url": "https://github.com/probot/dco#how-it-works",
-}
-`;
-
 exports[`dco pull_request event allowRemediationCommits.thirdParty: true creates a failing check with remidiation instructions 1`] = `
 Object {
   "actions": Array [
@@ -321,15 +312,6 @@ Commit sha: [<other ](https://github.com/robotland/test/pull/113/commits/<other 
 }
 `;
 
-exports[`dco pull_request event creates a error status if app has no access to checks 1`] = `
-Object {
-  "context": "DCO",
-  "description": "The sign-off is missing.",
-  "state": "failure",
-  "target_url": "https://github.com/probot/dco#how-it-works",
-}
-`;
-
 exports[`dco pull_request event creates a failing check 1`] = `
 Object {
   "actions": Array [
@@ -397,15 +379,6 @@ Object {
   },
   "started_at": "2018-07-14T18:18:54.156Z",
   "status": "completed",
-}
-`;
-
-exports[`dco pull_request event creates a passing status if app has no access to checks 1`] = `
-Object {
-  "context": "DCO",
-  "description": "All commits are signed off!",
-  "state": "success",
-  "target_url": "https://github.com/probot/dco#how-it-works",
 }
 `;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -83,6 +83,22 @@ function graphQLCommits(commits, pageInfo, options = {}) {
   };
 }
 
+function expectCommitStatusNotCalled(path) {
+  let called = false;
+  const scope = nock("https://api.github.com")
+    .post(path)
+    .reply(() => {
+      called = true;
+      return [201];
+    });
+
+  return () => {
+    expect(called).toBe(false);
+    expect(scope.isDone()).toBe(false);
+    nock.cleanAll();
+  };
+}
+
 function expectIncompleteCommitListCheck(body) {
   body.started_at = "2018-07-14T18:18:54.156Z";
   body.completed_at = "2018-07-14T18:18:54.156Z";
@@ -175,7 +191,10 @@ describe("dco", () => {
       expect(mock.activeMocks()).toStrictEqual([]);
     });
 
-    test("creates a passing status if app has no access to checks", async () => {
+    test("rethrows when passing check creation returns 403", async () => {
+      const assertCommitStatusNotCalled = expectCommitStatusNotCalled(
+        "/repos/octocat/Hello-World/statuses/34c5c7793cb3b279e22454cb6750c80560547b3a"
+      );
       const mock = nock("https://api.github.com")
         .get("/repos/octocat/Hello-World/contents/.github%2Fdco.yml")
         .reply(404)
@@ -187,21 +206,16 @@ describe("dco", () => {
         .reply(200, compareSuccessCommits)
 
         .post("/repos/octocat/Hello-World/check-runs")
-        .reply(403)
+        .reply(403);
 
-        .post(
-          "/repos/octocat/Hello-World/statuses/34c5c7793cb3b279e22454cb6750c80560547b3a",
-          (body) => {
-            expect(body).toMatchSnapshot();
-
-            return true;
-          }
-        )
-        .reply(201);
-
-      await probot.receive({ name: "pull_request", payload: payloadSuccess });
+      await expect(
+        probot.receive({ name: "pull_request", payload: payloadSuccess })
+      ).rejects.toMatchObject({
+        errors: [expect.objectContaining({ status: 403 })],
+      });
 
       expect(mock.activeMocks()).toStrictEqual([]);
+      assertCommitStatusNotCalled();
     });
 
     test("creates a failing check when commits cannot be listed", async () => {
@@ -998,8 +1012,9 @@ describe("dco", () => {
 
         .get("/repos/robotland/test/pulls/113/commits")
         .query({ per_page: "100" })
-        .reply(200, [])
+        .reply(200, []);
 
+      const checkRunMock = nock("https://api.github.com")
         .post("/repos/robotland/test/check-runs", (body) => {
           body.started_at = "2018-07-14T18:18:54.156Z";
           body.completed_at = "2018-07-14T18:18:54.156Z";
@@ -1021,6 +1036,59 @@ describe("dco", () => {
       await probot.receive({ name: "pull_request", payload });
 
       expect(mock.activeMocks()).toStrictEqual([]);
+      expect(checkRunMock.activeMocks()).toStrictEqual([]);
+    });
+
+    test("rethrows when no-commit check creation returns 403", async () => {
+      let checkRunRequests = 0;
+      const mock = nock("https://api.github.com")
+        .get("/repos/robotland/test/contents/.github%2Fdco.yml")
+        .reply(404)
+        .get("/repos/robotland/.github/contents/.github%2Fdco.yml")
+        .reply(404)
+
+        .get("/repos/robotland/test/pulls/113/commits")
+        .query({ per_page: "100" })
+        .reply(200, []);
+
+      const checkRunMock = nock("https://api.github.com")
+        .post("/repos/robotland/test/check-runs", (body) => {
+          checkRunRequests += 1;
+          expect(body).toMatchObject({
+            conclusion: "neutral",
+            head_branch: "dco-test",
+            head_sha: "e76ed6025cec8879c75454a6efd6081d46de4c94",
+            name: "DCO",
+            status: "completed",
+          });
+          expect(body.output.summary).toContain("returned no commits");
+          return true;
+        })
+        .reply(403);
+
+      const unmatchedCheckRunRequests = [];
+      const onNoMatch = (request) => {
+        const path = request.path || request.options?.path || request.href;
+        if (path?.includes("/repos/robotland/test/check-runs")) {
+          unmatchedCheckRunRequests.push(path);
+        }
+      };
+      nock.emitter.on("no match", onNoMatch);
+
+      try {
+        await expect(
+          probot.receive({ name: "pull_request", payload })
+        ).rejects.toMatchObject({
+          errors: [expect.objectContaining({ status: 403 })],
+        });
+      } finally {
+        nock.emitter.removeListener("no match", onNoMatch);
+      }
+
+      expect(mock.activeMocks()).toStrictEqual([]);
+      expect(checkRunMock.activeMocks()).toStrictEqual([]);
+      expect(unmatchedCheckRunRequests).toStrictEqual([]);
+      expect(checkRunRequests).toBe(1);
     });
 
     test("evaluates commits from paginated pull request commits", async () => {
@@ -1121,7 +1189,7 @@ describe("dco", () => {
       expect(mock.activeMocks()).toStrictEqual([]);
     });
 
-    test("rethrows when the failure status cannot be created", async () => {
+    test("rethrows when the failure check returns 403", async () => {
       const mock = nock("https://api.github.com")
         .get("/repos/robotland/test/contents/.github%2Fdco.yml")
         .reply(404)
@@ -1136,21 +1204,21 @@ describe("dco", () => {
         })
 
         .post("/repos/robotland/test/check-runs")
-        .reply(403)
-
-        .post(
-          "/repos/robotland/test/statuses/e76ed6025cec8879c75454a6efd6081d46de4c94"
-        )
         .reply(403);
 
       await expect(
         probot.receive({ name: "pull_request", payload })
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({
+        errors: [expect.objectContaining({ status: 403 })],
+      });
 
       expect(mock.activeMocks()).toStrictEqual([]);
     });
 
-    test("creates a error status if app has no access to checks", async () => {
+    test("rethrows when failing check creation returns 403", async () => {
+      const assertCommitStatusNotCalled = expectCommitStatusNotCalled(
+        "/repos/robotland/test/statuses/e76ed6025cec8879c75454a6efd6081d46de4c94"
+      );
       const mock = nock("https://api.github.com")
         .get("/repos/robotland/test/contents/.github%2Fdco.yml")
         .reply(404)
@@ -1162,21 +1230,16 @@ describe("dco", () => {
         .reply(200, compare.commits)
 
         .post("/repos/robotland/test/check-runs")
-        .reply(403)
+        .reply(403);
 
-        .post(
-          "/repos/robotland/test/statuses/e76ed6025cec8879c75454a6efd6081d46de4c94",
-          (body) => {
-            expect(body).toMatchSnapshot();
-
-            return true;
-          }
-        )
-        .reply(201);
-
-      await probot.receive({ name: "pull_request", payload });
+      await expect(
+        probot.receive({ name: "pull_request", payload })
+      ).rejects.toMatchObject({
+        errors: [expect.objectContaining({ status: 403 })],
+      });
 
       expect(mock.activeMocks()).toStrictEqual([]);
+      assertCommitStatusNotCalled();
     });
 
     describe("with custom configuration", () => {
@@ -1954,7 +2017,10 @@ allowRemediationCommits:
       expect(mock.activeMocks()).toStrictEqual([]);
     });
 
-    test("falls back to status API when check-runs returns 403", async () => {
+    test("rethrows when check-runs returns 403", async () => {
+      const assertCommitStatusNotCalled = expectCommitStatusNotCalled(
+        "/repos/robotland/test/statuses/abc123def456abc123def456abc123def456abc1"
+      );
       const mock = nock("https://api.github.com")
         .get("/repos/robotland/test/pulls/113")
         .reply(200, payload.pull_request)
@@ -1970,20 +2036,16 @@ allowRemediationCommits:
         .reply(200, compare)
 
         .post("/repos/robotland/test/check-runs")
-        .reply(403)
+        .reply(403);
 
-        .post(
-          "/repos/robotland/test/statuses/abc123def456abc123def456abc123def456abc1",
-          (body) => {
-            expect(body).toMatchSnapshot();
-            return true;
-          }
-        )
-        .reply(201);
-
-      await probot.receive({ name: "merge_group", payload: mergeGroupPayload });
+      await expect(
+        probot.receive({ name: "merge_group", payload: mergeGroupPayload })
+      ).rejects.toMatchObject({
+        errors: [expect.objectContaining({ status: 403 })],
+      });
 
       expect(mock.activeMocks()).toStrictEqual([]);
+      assertCommitStatusNotCalled();
     });
 
     test("creates a failing check when compare commits fails", async () => {


### PR DESCRIPTION
## Summary

`reportDCO` published DCO results with `checks.create()` and, on a
403, fell back to `repos.createCommitStatus()`. This removes that
commit-status fallback. The fallback call requires `statuses: write`.

The official app's registration does not request `statuses`. Its
permissions are `checks:write`, `contents:read`, `members:read`,
`merge_queues:read`, `metadata:read`, and `pull_requests:read`. GitHub
App permissions are app-level, and an installation can only approve what
the app requests, so no installation of the official app can hold
`statuses:write`. The fallback could only ever 403, and because the
second call was itself unguarded the rejection escaped and nothing was
reported at all, leaving the check stuck on "Expected — Waiting for
status to be reported".

Self-hosted deployments that manually granted `statuses:write` could
reach this path. They are intentionally no longer supported on it;
failing loudly is preferred over silently degrading to a commit status.

With this change, a failed `checks.create` is logged and rethrown, so the
failure is visible in Recent Deliveries and the delivery can be
redelivered.

The empty-commit-list neutral report was also moved outside the
evaluation try/catch so that a failure to publish is never misreported as
a failure to evaluate. Behaviour for the merge-group compare path is
unchanged.

`docs/administration.md` now records that results are published through
the Checks API and that `statuses` is not requested.

Closes #304
